### PR TITLE
Juliet Suite: Remove unused ldv_undef_ptr{,_non_null}

### DIFF
--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_01_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_01_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_02_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_02_good.i
@@ -1543,7 +1543,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1552,7 +1551,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1570,7 +1568,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1606,14 +1603,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1669,15 +1658,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_03_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_03_good.i
@@ -1543,7 +1543,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1552,7 +1551,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1570,7 +1568,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1606,14 +1603,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1669,15 +1658,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_04_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_04_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_05_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_05_good.i
@@ -1563,7 +1563,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1572,7 +1571,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1590,7 +1588,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1626,14 +1623,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1689,15 +1678,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_06_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_06_good.i
@@ -1562,7 +1562,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1571,7 +1570,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1589,7 +1587,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1625,14 +1622,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1688,15 +1677,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_07_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_07_good.i
@@ -1561,7 +1561,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1570,7 +1569,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1588,7 +1586,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1624,14 +1621,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1687,15 +1676,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_08_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_08_good.i
@@ -1603,7 +1603,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1612,7 +1611,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1630,7 +1628,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1666,14 +1663,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1729,15 +1718,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_09_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_09_good.i
@@ -1560,7 +1560,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1569,7 +1568,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1587,7 +1585,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1623,14 +1620,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1686,15 +1675,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_10_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_10_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_11_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_11_good.i
@@ -1583,7 +1583,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1592,7 +1591,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1610,7 +1608,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1646,14 +1643,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1709,15 +1698,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_12_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_12_good.i
@@ -1534,7 +1534,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1543,7 +1542,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1561,7 +1559,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1597,14 +1594,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1660,15 +1649,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_13_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_13_good.i
@@ -1560,7 +1560,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1569,7 +1568,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1587,7 +1585,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1623,14 +1620,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1686,15 +1675,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_14_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_14_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_15_bad.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_15_good.i
@@ -1663,7 +1663,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1672,7 +1671,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1690,7 +1688,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1726,14 +1723,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1789,15 +1778,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_16_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_16_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_17_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_17_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_18_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_18_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_21_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_21_good.i
@@ -1545,7 +1545,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1554,7 +1553,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1572,7 +1570,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1608,14 +1605,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1671,15 +1660,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_22_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_22_good.i
@@ -1555,7 +1555,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1564,7 +1563,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1582,7 +1580,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1618,14 +1615,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1681,15 +1670,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_31_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_31_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_32_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_32_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_34_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_34_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_41_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_41_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_42_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_42_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_44_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_44_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_45_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_45_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_51_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_51_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_52_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_52_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_53_bad.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_53_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_54_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_54_good.i
@@ -1494,7 +1494,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1503,7 +1502,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1521,7 +1519,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1557,14 +1554,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1620,15 +1609,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_61_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_61_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_63_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_63_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_64_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_64_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_65_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_65_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_66_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_66_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_67_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_67_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_68_bad.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_connect_socket_68_good.i
@@ -1452,7 +1452,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1461,7 +1460,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1479,7 +1477,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1515,14 +1512,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1578,15 +1567,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_01_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_01_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_02_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_02_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_03_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_03_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_04_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_04_good.i
@@ -1497,7 +1497,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1506,7 +1505,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1524,7 +1522,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1560,14 +1557,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1623,15 +1612,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_05_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_05_good.i
@@ -1496,7 +1496,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1505,7 +1504,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1523,7 +1521,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1559,14 +1556,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1622,15 +1611,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_06_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_06_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_07_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_07_good.i
@@ -1494,7 +1494,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1503,7 +1502,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1521,7 +1519,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1557,14 +1554,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1620,15 +1609,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_08_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_08_good.i
@@ -1536,7 +1536,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1545,7 +1544,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1563,7 +1561,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1599,14 +1596,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1662,15 +1651,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_09_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_09_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_10_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_10_good.i
@@ -1492,7 +1492,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1501,7 +1500,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1519,7 +1517,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1555,14 +1552,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1618,15 +1607,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_11_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_11_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_12_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_12_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_13_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_13_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_14_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_14_good.i
@@ -1492,7 +1492,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1501,7 +1500,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1519,7 +1517,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1555,14 +1552,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1618,15 +1607,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_15_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_15_good.i
@@ -1596,7 +1596,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1605,7 +1604,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1623,7 +1621,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1659,14 +1656,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1722,15 +1711,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_16_bad.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_16_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_17_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_17_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_18_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_18_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_21_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_21_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_22_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_22_good.i
@@ -1488,7 +1488,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1497,7 +1496,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1515,7 +1513,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1551,14 +1548,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1614,15 +1603,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_31_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_31_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_32_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_32_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_34_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_34_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_41_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_41_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_42_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_42_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_44_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_44_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_45_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_45_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_51_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_51_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_52_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_52_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_53_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_53_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_54_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_54_good.i
@@ -1458,7 +1458,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1467,7 +1466,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1485,7 +1483,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1521,14 +1518,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1584,15 +1573,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_61_bad.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_61_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_63_bad.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_63_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_64_bad.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_64_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_65_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_65_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_66_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_66_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_67_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_67_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_68_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fgets_68_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_01_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_01_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_02_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_02_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_03_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_03_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_04_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_04_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_05_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_05_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_06_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_06_good.i
@@ -1470,7 +1470,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1479,7 +1478,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1497,7 +1495,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1533,14 +1530,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1596,15 +1585,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_07_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_07_good.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_08_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_08_good.i
@@ -1511,7 +1511,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1520,7 +1519,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1538,7 +1536,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1574,14 +1571,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1637,15 +1626,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_09_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_09_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_10_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_10_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_11_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_11_good.i
@@ -1491,7 +1491,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1500,7 +1499,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1518,7 +1516,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1554,14 +1551,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1617,15 +1606,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_12_bad.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_12_good.i
@@ -1443,7 +1443,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1452,7 +1451,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1470,7 +1468,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1506,14 +1503,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1569,15 +1558,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_13_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_13_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_14_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_14_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_15_bad.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_15_good.i
@@ -1573,7 +1573,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1582,7 +1581,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1600,7 +1598,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1636,14 +1633,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1699,15 +1688,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_16_bad.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_16_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_17_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_17_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_18_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_18_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_21_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_21_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_22_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_22_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_31_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_31_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_32_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_32_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_34_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_34_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_41_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_41_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_42_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_42_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_44_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_44_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_45_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_45_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_51_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_51_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_52_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_52_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_53_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_53_good.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_54_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_54_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_61_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_61_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_63_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_63_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_64_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_64_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_65_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_65_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_66_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_66_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_67_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_67_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_68_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_fscanf_68_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_01_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_02_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_03_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_04_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_05_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_06_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_07_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_08_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_08_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_09_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_10_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_11_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_11_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_12_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_12_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_13_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_14_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_15_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_15_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_16_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_16_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_17_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_18_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_18_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_21_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_21_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_22_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_22_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_31_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_32_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_34_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_41_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_42_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_42_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_44_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_45_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_51_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_52_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_53_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_54_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_61_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_61_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_63_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_64_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_65_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_66_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_67_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_68_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_large_68_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_01_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_01_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_02_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_02_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_03_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_03_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_04_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_04_good.i
@@ -1599,7 +1599,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1608,7 +1607,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1626,7 +1624,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1662,14 +1659,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1725,15 +1714,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_05_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_05_good.i
@@ -1598,7 +1598,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1607,7 +1606,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1625,7 +1623,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1661,14 +1658,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1724,15 +1713,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_06_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_06_good.i
@@ -1597,7 +1597,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1606,7 +1605,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1624,7 +1622,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1660,14 +1657,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1723,15 +1712,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_07_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_07_good.i
@@ -1596,7 +1596,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1605,7 +1604,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1623,7 +1621,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1659,14 +1656,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1722,15 +1711,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_08_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_08_good.i
@@ -1638,7 +1638,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1647,7 +1646,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1665,7 +1663,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1701,14 +1698,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1764,15 +1753,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_09_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_09_good.i
@@ -1595,7 +1595,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1604,7 +1603,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1622,7 +1620,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1658,14 +1655,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1721,15 +1710,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_10_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_10_good.i
@@ -1594,7 +1594,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1603,7 +1602,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1621,7 +1619,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1657,14 +1654,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1720,15 +1709,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_11_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_11_good.i
@@ -1618,7 +1618,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1627,7 +1626,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1645,7 +1643,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1681,14 +1678,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1744,15 +1733,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_12_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_12_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_13_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_13_good.i
@@ -1595,7 +1595,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1604,7 +1603,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1622,7 +1620,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1658,14 +1655,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1721,15 +1710,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_14_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_14_good.i
@@ -1594,7 +1594,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1603,7 +1602,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1621,7 +1619,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1657,14 +1654,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1720,15 +1709,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_15_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_15_good.i
@@ -1698,7 +1698,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1707,7 +1706,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1725,7 +1723,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1761,14 +1758,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1824,15 +1813,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_16_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_16_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_17_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_17_good.i
@@ -1501,7 +1501,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1510,7 +1509,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1528,7 +1526,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1564,14 +1561,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1627,15 +1616,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_18_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_18_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_21_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_21_good.i
@@ -1580,7 +1580,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1589,7 +1588,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1607,7 +1605,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1643,14 +1640,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1706,15 +1695,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_22_bad.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_22_good.i
@@ -1590,7 +1590,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1599,7 +1598,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1617,7 +1615,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1653,14 +1650,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1716,15 +1705,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_31_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_31_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_32_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_32_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_34_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_34_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_41_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_41_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_42_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_42_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_44_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_44_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_45_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_45_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_51_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_51_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_52_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_52_good.i
@@ -1477,7 +1477,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1486,7 +1485,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1504,7 +1502,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1540,14 +1537,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1603,15 +1592,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_53_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_53_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_54_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_54_good.i
@@ -1513,7 +1513,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1522,7 +1521,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1540,7 +1538,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1576,14 +1573,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1639,15 +1628,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_61_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_61_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_63_bad.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_63_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_64_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_64_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_65_bad.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_65_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_66_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_66_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_67_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_67_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_68_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_listen_socket_68_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_01_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_01_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_02_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_02_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_03_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_03_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_04_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_04_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_05_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_05_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_06_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_06_good.i
@@ -1484,7 +1484,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1493,7 +1492,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1511,7 +1509,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1547,14 +1544,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1610,15 +1599,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_07_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_07_good.i
@@ -1483,7 +1483,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1492,7 +1491,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1510,7 +1508,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1546,14 +1543,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1609,15 +1598,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_08_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_08_good.i
@@ -1525,7 +1525,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1534,7 +1533,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1552,7 +1550,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1588,14 +1585,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1651,15 +1640,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_09_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_09_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_10_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_10_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_11_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_11_good.i
@@ -1505,7 +1505,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1514,7 +1513,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1532,7 +1530,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1568,14 +1565,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1631,15 +1620,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_12_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_12_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_13_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_13_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_14_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_14_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_15_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_15_good.i
@@ -1581,7 +1581,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1590,7 +1589,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1608,7 +1606,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1644,14 +1641,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1707,15 +1696,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_16_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_16_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_17_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_17_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_18_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_18_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_21_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_21_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_22_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_22_good.i
@@ -1473,7 +1473,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1482,7 +1481,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1500,7 +1498,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1536,14 +1533,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1599,15 +1588,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_31_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_31_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_32_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_32_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_34_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_34_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_41_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_41_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_42_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_42_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_44_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_44_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_45_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_45_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_51_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_51_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_52_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_52_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_53_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_53_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_54_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_54_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_61_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_61_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_63_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_63_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_64_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_64_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_65_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_65_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_66_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_66_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_67_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_67_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_68_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE129_rand_68_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_01_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_02_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_02_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_03_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_03_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_04_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_04_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_05_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_05_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_06_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_06_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_07_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_07_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_08_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_08_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_09_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_09_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_10_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_10_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_11_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_11_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_12_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_12_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_13_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_13_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_14_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_14_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_15_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_16_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_17_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_18_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_31_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_31_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_32_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_32_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_34_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_34_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_41_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_44_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_45_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_45_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_52_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_53_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_63_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_64_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_64_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_66_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_67_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_67_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_68_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_loop_68_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_01_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_01_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_02_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_02_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_03_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_03_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_04_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_04_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_05_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_05_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_06_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_06_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_07_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_07_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_08_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_08_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_09_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_09_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_10_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_10_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_11_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_11_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_12_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_12_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_13_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_13_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_14_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_14_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_15_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_15_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_16_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_16_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_17_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_17_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_18_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_18_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_31_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_31_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_32_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_32_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_34_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_34_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_41_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_41_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_44_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_44_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_45_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_45_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_51_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_51_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_52_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_52_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_53_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_53_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_54_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_54_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_63_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_63_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_64_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_64_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_65_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_65_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_66_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_66_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_67_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_67_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_68_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memcpy_68_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_01_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_01_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_02_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_02_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_03_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_03_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_04_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_04_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_05_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_05_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_06_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_06_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_07_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_07_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_08_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_08_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_09_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_09_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_10_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_10_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_11_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_11_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_12_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_12_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_13_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_13_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_14_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_14_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_15_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_15_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_16_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_16_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_17_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_17_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_18_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_18_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_31_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_31_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_32_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_32_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_34_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_34_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_41_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_41_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_44_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_44_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_45_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_45_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_51_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_51_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_52_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_52_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_53_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_53_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_54_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_54_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_63_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_63_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_64_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_64_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_65_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_65_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_66_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_66_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_67_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_67_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_68_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE131_memmove_68_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_01_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_02_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_03_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_04_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_05_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_06_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_07_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_08_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_09_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_10_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_11_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_12_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_12_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_13_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_14_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_15_good.i
@@ -1499,7 +1499,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1508,7 +1507,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1526,7 +1524,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1562,14 +1559,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1625,15 +1614,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_16_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_17_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_17_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_18_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_18_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_21_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_21_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_22_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_22_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_31_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_32_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_34_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_41_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_41_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_42_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_42_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_44_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_44_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_45_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_51_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_51_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_52_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_53_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_53_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_54_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_61_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_61_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_63_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_64_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_65_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_65_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_66_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_67_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE135_68_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_01_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_02_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_02_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_03_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_03_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_04_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_05_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_06_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_07_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_08_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_09_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_10_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_11_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_12_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_12_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_13_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_14_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_15_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_16_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_17_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_18_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_31_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_31_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_32_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_32_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_34_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_34_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_41_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_44_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_45_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_45_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_51_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_51_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_52_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_52_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_53_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_63_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_64_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_64_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_66_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_67_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_67_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_68_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_cpy_68_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_01_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_01_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_02_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_02_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_03_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_03_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_04_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_04_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_05_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_05_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_06_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_06_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_07_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_07_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_08_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_08_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_09_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_09_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_10_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_10_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_11_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_11_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_12_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_12_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_13_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_13_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_14_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_14_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_15_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_15_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_16_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_16_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_17_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_17_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_18_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memcpy_18_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_02_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_03_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_04_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_05_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_06_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_07_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_08_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_09_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_10_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_11_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_12_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_13_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_14_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_15_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_15_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_16_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_16_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_17_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_17_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_18_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s01---CWE121_Stack_Based_Buffer_Overflow__char_type_overrun_memmove_18_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_01_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_01_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_02_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_02_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_03_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_03_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_04_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_04_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_05_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_05_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_06_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_06_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_07_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_07_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_08_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_08_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_09_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_09_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_10_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_10_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_11_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_11_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_12_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_12_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_13_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_13_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_14_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_14_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_15_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_16_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_17_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_18_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_18_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_31_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_31_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_32_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_32_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_34_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_34_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_41_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_41_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_44_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_44_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_45_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_45_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_51_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_51_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_53_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_54_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_54_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_64_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_64_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_65_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_65_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_66_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_66_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_67_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_67_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_68_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_loop_68_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_01_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_02_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_03_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_04_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_04_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_05_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_05_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_06_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_06_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_07_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_07_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_08_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_08_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_09_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_09_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_10_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_10_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_11_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_11_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_12_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_12_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_13_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_13_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_14_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_14_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_15_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_15_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_16_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_16_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_17_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_17_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_18_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_18_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_31_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_32_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_34_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_41_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_41_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_44_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_44_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_45_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_52_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_53_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_53_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_54_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_54_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_63_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_63_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_65_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_65_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_66_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_66_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_67_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_68_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memcpy_68_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_02_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_03_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_04_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_05_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_06_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_07_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_08_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_09_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_10_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_11_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_12_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_12_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_13_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_14_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_15_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_52_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_53_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_53_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_54_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_65_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_memmove_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_01_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_01_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_02_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_03_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_04_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_04_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_05_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_05_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_06_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_06_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_07_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_07_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_08_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_08_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_09_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_09_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_10_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_10_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_11_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_11_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_12_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_12_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_13_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_13_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_14_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_14_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_15_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_15_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_16_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_16_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_17_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_17_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_18_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_18_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_31_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_31_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_32_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_32_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_34_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_34_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_41_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_41_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_44_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_44_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_45_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_45_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_51_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_51_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_52_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_53_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_53_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_54_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_54_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_63_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_63_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_64_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_64_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_65_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_65_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_66_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_66_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_67_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_67_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_68_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_alloca_ncpy_68_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_01_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_02_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_03_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_04_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_05_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_06_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_07_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_08_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_09_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_10_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_11_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_12_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_13_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_14_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_31_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_32_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_34_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_45_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_51_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_51_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_52_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_52_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_53_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_53_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_54_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_54_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_63_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_64_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_65_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_66_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_66_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_67_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_cpy_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_01_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_01_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_02_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_02_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_03_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_03_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_04_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_04_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_05_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_05_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_06_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_06_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_07_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_07_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_08_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_08_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_09_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_09_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_10_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_10_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_11_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_11_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_12_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_12_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_13_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_13_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_14_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_14_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_15_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_16_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_17_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_18_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_31_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_31_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_32_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_32_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_34_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_34_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_41_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_41_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_44_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_44_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_45_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_45_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_51_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_51_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_52_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_52_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_53_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_53_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_54_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_54_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_63_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_63_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_64_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_64_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_65_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_65_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_66_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_66_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_67_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_67_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_68_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_loop_68_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_01_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_02_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_03_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_04_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_05_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_06_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_07_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_08_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_09_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_10_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_11_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_12_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_13_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_14_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_15_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_16_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_17_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_18_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_31_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_32_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_34_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_41_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_41_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_44_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_44_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_45_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_51_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_51_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_52_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_53_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_63_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_65_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_66_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memcpy_68_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_01_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_02_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_03_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_04_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_04_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_05_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_05_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_06_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_06_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_07_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_07_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_08_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_09_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_09_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_10_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_10_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_11_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_12_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_13_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_13_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_14_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_14_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_15_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_16_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_17_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_18_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_31_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_32_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_34_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_41_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_41_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_44_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_45_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_51_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_51_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_52_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_53_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_54_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_65_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_66_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_67_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_memmove_68_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_01_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_01_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_02_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_02_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_03_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_03_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_04_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_05_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_06_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_07_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_08_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_08_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_09_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_10_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_11_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_11_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_12_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_12_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_13_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_14_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_15_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_15_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_16_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_16_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_17_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_17_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_18_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_18_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_31_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_31_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_32_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_32_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_34_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_34_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_41_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_41_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_44_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_44_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_45_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_45_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_51_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_51_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_52_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_52_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_53_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_53_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_54_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_54_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_63_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_63_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_64_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_64_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_65_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_65_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_66_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_66_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_67_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_67_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_68_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s02---CWE121_Stack_Based_Buffer_Overflow__CWE193_char_declare_ncpy_68_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_01_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_02_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_03_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_04_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_04_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_05_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_05_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_06_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_06_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_07_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_07_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_08_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_08_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_09_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_09_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_10_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_10_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_11_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_11_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_12_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_12_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_13_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_13_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_14_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_14_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_15_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_16_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_16_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_17_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_18_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_31_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_32_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_34_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_41_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_45_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_51_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_64_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_65_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_66_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_66_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_67_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_68_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_loop_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_01_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_02_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_03_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_04_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_04_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_05_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_05_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_06_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_06_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_07_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_07_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_08_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_08_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_09_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_09_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_10_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_10_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_11_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_11_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_12_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_12_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_13_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_13_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_14_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_14_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_15_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_16_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_17_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_18_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_31_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_32_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_34_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_41_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_41_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_44_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_44_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_45_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_51_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_51_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_53_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_53_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_54_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_63_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_63_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_65_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_65_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memcpy_68_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_04_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_05_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_05_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_06_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_07_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_07_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_08_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_08_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_09_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_10_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_10_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_11_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_11_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_12_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_12_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_13_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_14_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_14_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_15_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_53_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_53_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_54_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_54_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_63_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_63_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_memmove_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_01_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_02_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_02_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_03_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_03_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_04_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_05_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_06_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_07_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_08_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_09_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_10_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_11_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_12_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_13_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_14_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_15_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_31_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_32_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_34_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_45_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_51_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_52_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_52_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_53_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_54_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_63_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_64_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_65_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_66_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_67_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncat_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_02_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_03_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_04_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_05_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_06_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_07_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_08_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_09_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_10_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_11_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_12_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_12_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_13_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_14_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_15_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_52_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_54_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_64_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_64_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_65_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_ncpy_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_01_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_02_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_02_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_03_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_03_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_04_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_05_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_06_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_07_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_08_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_09_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_10_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_11_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_12_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_13_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_14_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_15_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_31_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_32_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_34_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_45_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_51_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_52_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_53_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_54_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_54_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_63_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_63_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_64_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_65_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_65_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_66_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_67_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_alloca_snprintf_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_02_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_03_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_04_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_05_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_06_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_07_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_08_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_09_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_10_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_11_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_12_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_12_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_13_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_14_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_15_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_52_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_53_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_53_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_54_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_54_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_63_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_64_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_64_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_65_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_loop_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_01_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_01_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_02_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_02_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_03_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_03_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_04_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_04_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_05_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_05_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_06_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_06_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_07_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_07_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_08_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_08_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_09_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_09_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_10_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_10_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_11_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_11_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_12_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_13_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_13_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_14_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_14_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_15_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_15_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_16_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_16_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_17_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_17_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_18_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_18_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_31_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_31_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_32_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_32_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_34_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_34_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_41_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_41_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_44_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_44_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_45_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_45_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_51_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_51_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_52_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_53_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_53_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_54_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_54_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_63_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_63_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_64_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_64_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_65_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_65_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_66_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_66_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_67_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_67_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_68_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memcpy_68_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_01_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_02_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_03_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_04_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_05_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_06_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_07_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_08_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_08_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_09_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_10_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_11_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_11_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_12_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_12_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_13_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_14_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_15_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_15_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_16_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_16_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_17_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_17_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_18_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_18_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_31_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_32_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_34_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_41_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_44_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_45_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_51_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_52_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_53_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_53_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_54_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_63_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_63_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_64_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_64_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_65_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_66_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_66_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_67_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_memmove_68_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_02_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_03_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_04_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_06_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_09_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_12_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_12_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_13_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_15_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_16_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_17_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_18_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_31_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_32_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_34_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_41_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_44_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_45_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_51_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_51_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_52_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_52_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_53_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_53_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_54_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_63_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_64_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_65_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_65_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_66_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncat_68_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_01_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_02_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_03_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_04_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_04_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_05_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_05_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_06_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_06_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_07_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_07_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_08_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_09_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_09_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_10_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_10_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_11_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_12_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_13_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_13_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_14_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_14_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_15_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_16_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_17_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_18_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_31_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_32_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_34_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_41_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_41_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_44_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_45_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_51_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_51_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_52_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_53_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_54_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_65_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_66_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_67_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s03---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_ncpy_68_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_02_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_03_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_04_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_06_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_09_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_12_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_12_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_13_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_15_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_16_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_17_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_18_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_31_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_32_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_34_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_41_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_44_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_45_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_51_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_51_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_52_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_52_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_53_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_53_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_54_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_63_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_64_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_65_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_65_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_66_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_char_declare_snprintf_68_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_01_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_05_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_07_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_08_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_10_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_11_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_12_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_14_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_15_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_16_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_17_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_18_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_31_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_32_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_34_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_41_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_41_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_44_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_45_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_51_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_51_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_52_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_53_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_54_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_54_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_64_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_64_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_65_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_66_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_67_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_loop_68_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_01_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_01_good.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_02_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_02_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_03_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_03_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_04_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_04_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_05_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_05_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_06_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_06_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_07_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_07_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_08_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_08_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_09_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_09_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_10_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_10_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_11_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_11_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_12_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_12_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_13_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_13_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_14_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_14_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_15_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_15_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_16_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_16_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_17_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_17_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_18_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_18_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_31_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_31_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_32_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_32_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_34_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_34_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_41_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_41_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_44_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_44_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_45_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_45_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_51_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_52_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_53_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_53_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_54_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_54_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_63_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_63_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_64_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_64_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_65_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_66_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_66_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_67_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_67_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_68_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memcpy_68_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_01_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_01_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_02_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_02_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_03_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_03_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_04_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_04_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_05_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_05_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_06_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_06_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_07_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_07_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_08_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_08_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_09_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_09_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_10_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_10_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_11_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_11_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_12_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_12_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_13_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_13_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_14_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_14_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_15_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_16_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_16_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_17_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_17_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_18_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_18_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_31_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_31_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_32_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_32_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_34_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_34_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_41_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_41_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_44_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_44_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_45_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_45_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_51_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_52_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_53_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_53_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_54_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_54_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_63_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_63_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_64_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_64_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_65_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_66_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_66_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_67_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_67_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_68_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_alloca_memmove_68_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_01_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_02_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_02_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_03_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_03_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_04_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_04_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_05_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_05_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_06_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_06_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_07_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_07_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_08_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_08_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_09_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_09_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_10_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_10_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_11_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_11_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_12_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_12_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_13_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_13_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_14_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_14_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_15_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_16_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_17_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_18_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_31_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_31_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_32_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_32_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_34_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_34_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_41_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_44_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_45_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_45_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_52_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_52_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_53_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_54_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_54_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_63_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_64_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_66_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_67_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_67_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_68_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_loop_68_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_01_good.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_02_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_03_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_04_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_04_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_05_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_05_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_06_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_06_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_07_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_07_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_08_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_08_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_09_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_09_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_10_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_10_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_11_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_11_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_12_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_12_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_13_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_13_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_14_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_14_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_15_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_15_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_16_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_17_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_17_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_18_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_18_good.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_31_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_31_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_32_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_32_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_34_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_34_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_41_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_44_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_45_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_45_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_51_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_51_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_52_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_53_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_53_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_54_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_63_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_63_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_64_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_64_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_65_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_66_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_66_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_67_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_67_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_68_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memcpy_68_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_01_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_01_good.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_02_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_02_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_03_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_03_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_04_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_04_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_05_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_05_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_06_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_06_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_07_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_07_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_08_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_08_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_09_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_09_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_10_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_10_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_11_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_11_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_12_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_12_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_13_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_13_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_14_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_14_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_15_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_15_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_16_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_16_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_17_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_17_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_18_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_18_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_31_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_31_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_32_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_32_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_34_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_34_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_41_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_41_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_44_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_44_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_45_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_45_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_51_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_52_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_53_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_53_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_54_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_63_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_63_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_64_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_64_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_65_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_65_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_66_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_66_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_67_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_67_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_68_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int64_t_declare_memmove_68_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_01_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_05_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_07_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_08_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_10_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_11_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_12_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_14_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_15_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_16_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_17_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_18_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_31_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_32_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_34_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_41_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_41_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_44_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_45_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_51_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_52_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_52_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_53_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_65_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_66_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_67_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_loop_68_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_01_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_01_good.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_02_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_02_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_03_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_03_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_04_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_04_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_05_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_05_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_06_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_06_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_07_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_07_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_08_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_08_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_09_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_09_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_10_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_10_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_11_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_11_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_12_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_12_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_13_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_13_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_14_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_14_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_15_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_15_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_16_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_16_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_17_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_17_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_18_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_18_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_31_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_31_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_32_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_32_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_34_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_34_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_41_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_41_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_44_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_44_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_45_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_45_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_51_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_52_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_53_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_53_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_54_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_54_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_63_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_63_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_64_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_64_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_65_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_66_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_66_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_67_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_67_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_68_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memcpy_68_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_01_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_01_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_02_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_02_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_03_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_03_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_04_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_04_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_05_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_05_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_06_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_06_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_07_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_07_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_08_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_08_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_09_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_09_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_10_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_10_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_11_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_11_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_12_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_12_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_13_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_13_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_14_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_14_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_15_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_16_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_16_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_17_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_17_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_18_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_18_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_31_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_31_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_32_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_32_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_34_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_34_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_41_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_41_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_44_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_44_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_45_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_45_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_51_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_52_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_53_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_53_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_54_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_54_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_63_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_63_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_64_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_64_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_65_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_66_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_66_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_67_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_67_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_68_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_alloca_memmove_68_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_01_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_02_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_02_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_03_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_03_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_04_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_04_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_05_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_05_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_06_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_06_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_07_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_07_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_08_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_08_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_09_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_09_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_10_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_10_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_11_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_11_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_12_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_12_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_13_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_13_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_14_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_14_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_15_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_16_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_17_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_18_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_31_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_31_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_32_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_32_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_34_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_34_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_41_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_44_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_45_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_45_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_51_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_51_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_53_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_54_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_54_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_63_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_64_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_64_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_66_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_67_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_67_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_68_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_loop_68_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_01_good.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_02_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_03_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_04_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_04_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_05_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_05_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_06_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_06_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_07_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_07_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_08_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_08_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_09_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_09_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_10_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_10_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_11_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_11_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_12_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_12_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_13_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_13_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_14_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_14_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_15_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_15_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_16_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_17_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_17_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_18_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_18_good.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_31_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_31_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_32_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_32_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_34_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_34_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_41_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_44_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_45_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_45_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_51_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_51_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_52_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_52_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_53_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_53_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_54_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_63_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_63_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_64_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_64_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_65_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_66_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_66_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_67_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_67_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_68_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memcpy_68_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_01_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_01_good.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_02_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_02_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_03_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_03_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_04_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_04_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_05_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_05_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_06_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_06_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_07_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_07_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_08_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_08_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_09_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_09_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_10_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_10_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_11_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_11_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_12_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_12_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_13_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_13_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_14_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_14_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_15_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_15_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_16_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_16_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_17_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_17_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_18_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_18_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_31_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_31_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_32_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_32_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_34_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_34_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_41_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_41_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_44_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_44_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_45_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_45_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_51_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_52_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_52_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_53_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_53_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_54_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_63_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_63_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_64_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_64_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_65_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_65_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_66_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_66_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_67_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_67_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_68_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_int_declare_memmove_68_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_01_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_01_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_02_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_02_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_03_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_03_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_04_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_06_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_08_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_09_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_11_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_12_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_12_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_13_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_15_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_15_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_16_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_16_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_17_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_17_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_18_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_31_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_31_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_32_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_32_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_34_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_34_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_41_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_44_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_45_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_45_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_53_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_53_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_63_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_63_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_64_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_64_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_66_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_66_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_68_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_loop_68_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_01_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_01_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_02_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_02_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_03_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_03_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_04_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_04_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_05_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_05_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_06_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_06_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_07_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_07_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_08_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_08_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_09_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_09_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_10_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_10_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_11_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_11_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_12_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_12_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_13_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_13_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_14_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_14_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_15_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_16_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_16_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_17_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_17_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_18_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_18_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_31_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_31_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_32_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_32_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_34_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_34_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_41_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_44_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_45_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_45_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_51_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_52_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_52_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_53_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_54_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_63_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_63_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_64_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_64_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_65_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_66_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_67_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_67_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_68_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s04---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memcpy_68_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_01_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_01_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_02_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_02_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_03_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_03_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_04_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_06_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_08_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_09_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_11_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_12_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_12_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_13_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_15_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_16_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_16_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_17_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_17_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_18_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_18_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_31_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_32_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_32_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_34_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_34_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_41_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_44_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_45_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_45_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_51_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_52_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_53_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_54_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_63_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_63_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_64_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_65_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_66_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_66_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_67_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_67_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_68_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_alloca_memmove_68_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_01_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_02_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_03_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_04_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_04_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_05_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_05_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_06_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_06_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_07_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_07_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_08_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_08_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_09_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_09_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_10_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_10_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_11_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_11_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_12_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_12_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_13_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_13_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_14_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_14_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_15_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_16_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_18_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_31_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_32_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_34_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_41_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_41_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_44_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_44_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_45_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_51_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_51_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_52_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_52_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_53_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_53_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_54_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_54_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_63_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_64_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_65_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_65_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_66_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_67_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_68_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_loop_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_05_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_07_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_08_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_10_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_11_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_12_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_14_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_15_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_16_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_17_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_31_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_32_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_34_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_41_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_44_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_45_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_53_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_64_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_66_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_67_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memcpy_68_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_01_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_02_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_03_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_04_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_04_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_05_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_05_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_06_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_06_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_07_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_07_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_08_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_09_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_09_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_10_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_10_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_11_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_12_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_12_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_13_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_13_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_14_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_14_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_15_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_16_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_17_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_31_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_32_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_34_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_41_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_44_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_52_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_52_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_64_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_66_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_67_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s05---CWE121_Stack_Based_Buffer_Overflow__CWE805_struct_declare_memmove_68_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_01_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_01_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_02_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_02_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_03_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_03_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_04_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_04_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_05_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_05_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_06_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_06_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_07_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_07_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_08_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_08_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_09_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_09_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_10_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_10_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_11_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_11_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_12_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_12_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_13_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_13_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_14_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_14_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_15_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_15_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_16_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_16_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_17_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_17_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_18_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_18_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_21_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_21_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_22_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_22_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_31_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_31_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_32_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_32_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_34_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_34_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_41_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_41_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_42_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_42_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_44_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_44_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_45_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_45_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_51_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_51_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_52_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_52_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_53_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_53_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_54_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_54_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_61_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_61_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_63_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_64_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_64_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_65_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_65_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_66_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_67_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_68_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_loop_68_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_01_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_01_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_02_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_02_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_03_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_03_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_04_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_05_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_06_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_07_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_08_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_09_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_10_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_11_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_12_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_12_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_13_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_14_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_15_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_16_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_16_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_17_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_17_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_18_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_18_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_21_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_22_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_31_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_32_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_32_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_34_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_34_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_41_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_42_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_42_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_44_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_45_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_45_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_51_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_51_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_52_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_52_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_53_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_54_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_61_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_61_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_63_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_63_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_64_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_64_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_65_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_66_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_66_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_67_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_67_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_68_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memcpy_68_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_01_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_01_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_02_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_02_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_03_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_03_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_04_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_04_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_05_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_05_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_06_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_06_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_07_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_07_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_08_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_08_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_09_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_09_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_10_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_10_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_11_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_11_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_12_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_12_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_13_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_13_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_14_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_14_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_15_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_15_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_16_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_16_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_17_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_17_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_18_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_18_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_21_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_21_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_22_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_22_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_31_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_31_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_32_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_32_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_34_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_34_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_41_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_41_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_42_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_42_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_44_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_44_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_45_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_45_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_51_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_51_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_52_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_52_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_53_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_53_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_54_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_54_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_61_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_61_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_63_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_64_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_64_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_65_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_65_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_66_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_66_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_67_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_67_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_68_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_memmove_68_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_01_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_01_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_02_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_02_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_03_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_03_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_04_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_04_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_05_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_05_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_06_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_06_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_07_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_07_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_08_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_08_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_09_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_09_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_10_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_10_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_11_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_11_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_12_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_12_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_13_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_13_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_14_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_14_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_15_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_15_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_16_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_16_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_17_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_17_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_18_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_18_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_21_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_21_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_22_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_22_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_31_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_31_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_32_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_32_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_34_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_34_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_41_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_41_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_42_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_42_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_44_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_44_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_45_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_45_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_51_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_51_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_52_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_52_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_53_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_54_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_61_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_61_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_63_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_64_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_64_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_65_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_65_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_66_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_66_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_67_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_67_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_68_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncat_68_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_02_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_03_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_04_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_05_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_06_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_07_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_08_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_09_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_10_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_11_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_12_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_13_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_14_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_15_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_21_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_21_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_22_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_22_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_42_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_53_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_53_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_54_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_54_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_61_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_61_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_64_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_64_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_65_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_65_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_67_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_67_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_ncpy_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_01_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_01_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_02_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_02_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_03_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_03_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_04_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_04_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_05_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_05_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_06_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_06_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_07_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_07_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_08_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_08_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_09_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_09_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_10_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_10_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_11_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_11_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_12_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_12_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_13_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_13_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_14_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_14_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_15_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_15_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_16_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_16_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_17_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_17_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_18_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_18_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_21_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_21_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_22_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_22_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_31_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_31_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_32_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_32_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_34_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_34_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_41_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_41_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_42_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_42_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_44_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_44_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_45_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_45_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_51_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_51_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_52_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_53_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_53_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_54_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_54_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_61_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_61_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_63_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_64_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_64_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_65_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_65_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_66_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_66_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_67_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_67_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_68_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_alloca_snprintf_68_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_01_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_02_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_02_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_03_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_03_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_04_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_04_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_05_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_05_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_06_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_06_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_07_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_07_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_08_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_08_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_09_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_09_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_10_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_10_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_11_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_11_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_12_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_12_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_13_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_13_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_14_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_14_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_15_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_15_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_16_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_18_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_21_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_21_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_22_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_22_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_31_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_32_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_34_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_41_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_41_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_42_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_42_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_44_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_44_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_45_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_51_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_51_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_52_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_52_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_53_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_53_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_54_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_54_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_61_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_61_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_63_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_64_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_64_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_65_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_65_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_66_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_67_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_68_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_loop_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_01_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_01_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_02_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_02_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_03_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_03_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_04_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_05_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_06_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_07_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_08_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_08_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_09_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_10_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_11_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_11_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_12_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_12_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_13_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_14_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_15_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_16_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_16_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_17_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_17_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_18_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_18_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_21_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_21_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_22_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_22_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_31_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_31_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_32_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_32_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_34_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_34_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_41_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_42_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_42_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_44_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_45_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_45_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_51_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_52_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_53_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_54_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_54_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_61_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_61_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_63_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_63_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_64_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_65_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_66_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_67_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_67_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_68_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memcpy_68_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_01_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_01_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_02_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_02_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_03_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_03_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_04_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_05_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_06_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_07_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_08_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_09_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_10_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_11_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_12_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_12_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_13_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_14_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_15_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_16_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_16_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_17_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_17_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_18_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_18_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_21_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_22_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_31_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_32_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_32_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_34_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_34_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_41_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_42_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_42_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_44_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_45_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_45_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_51_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_52_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_53_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_54_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_54_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_61_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_61_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_63_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_63_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_64_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_65_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_66_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_66_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_67_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_67_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_68_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_memmove_68_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_01_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_01_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_02_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_02_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_03_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_03_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_04_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_05_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_06_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_07_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_08_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_09_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_10_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_11_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_12_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_12_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_13_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_14_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_15_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_16_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_16_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_17_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_17_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_18_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_18_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_21_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_22_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_31_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_32_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_32_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_34_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_34_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_41_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_42_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_42_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_44_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_45_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_45_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_51_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_52_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_52_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_53_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_54_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_61_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_61_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_63_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_64_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_65_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_66_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_66_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_67_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_67_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_68_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncat_68_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_01_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_01_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_02_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_02_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_03_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_03_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_04_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_04_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_05_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_05_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_06_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_06_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_07_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_07_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_08_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_08_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_09_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_09_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_10_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_10_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_11_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_11_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_12_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_12_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_13_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_13_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_14_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_14_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_15_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_16_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_17_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_18_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_18_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_21_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_21_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_22_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_22_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_31_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_31_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_32_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_32_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_34_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_34_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_41_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_41_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_42_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_42_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_44_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_44_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_45_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_45_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_52_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_52_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_53_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_54_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_54_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_61_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_61_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_63_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_63_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_64_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_64_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_65_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_65_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_67_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_67_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_68_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s06---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_ncpy_68_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_02_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_03_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_04_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_05_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_06_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_07_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_08_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_09_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_10_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_11_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_12_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_12_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_13_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_14_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_15_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_21_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_21_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_22_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_22_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_42_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_42_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_51_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_51_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_52_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_54_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_54_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_61_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_61_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_65_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_65_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_66_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_66_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s07---CWE121_Stack_Based_Buffer_Overflow__CWE806_char_declare_snprintf_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_01_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_02_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_02_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_03_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_03_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_04_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_05_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_06_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_07_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_08_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_09_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_10_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_11_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_12_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_13_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_14_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_15_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_31_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_32_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_34_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_45_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_51_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_52_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_53_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_53_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_54_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_63_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_64_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_65_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_66_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_67_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_67_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cat_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_01_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_02_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_03_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_04_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_04_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_05_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_05_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_06_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_06_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_07_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_07_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_08_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_08_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_09_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_09_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_10_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_10_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_11_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_11_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_12_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_12_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_13_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_13_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_14_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_14_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_15_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_16_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_17_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_31_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_32_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_34_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_41_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_44_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_64_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_65_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_66_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_66_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_67_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_alloca_cpy_68_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_02_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_03_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_04_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_06_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_09_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_12_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_12_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_13_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_15_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_16_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_17_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_18_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_31_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_32_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_34_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_41_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_44_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_45_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_51_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_51_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_52_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_52_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_53_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_53_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_54_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_63_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_64_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_65_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_65_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_66_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_67_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cat_68_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_01_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_01_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_02_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_02_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_03_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_03_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_08_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_11_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_12_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_12_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_15_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_15_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_16_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_16_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_17_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_17_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_18_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_18_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_31_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_31_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_32_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_32_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_34_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_34_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_41_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_41_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_44_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_44_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_45_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_45_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_51_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_51_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_52_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_52_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_53_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_53_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_54_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_54_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_63_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_63_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_64_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_64_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_65_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_65_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_66_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_66_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_67_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_67_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_68_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__dest_char_declare_cpy_68_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_01_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_01_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_02_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_02_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_03_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_03_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_04_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_06_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_08_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_09_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_11_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_12_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_12_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_13_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_15_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_15_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_16_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_16_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_17_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_17_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_18_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_18_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_21_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_21_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_22_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_22_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_31_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_31_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_32_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_32_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_34_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_34_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_41_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_41_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_42_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_42_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_44_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_44_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_45_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_45_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_51_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_52_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_53_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_53_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_54_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_54_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_61_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_61_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_63_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_63_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_64_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_65_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_65_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_66_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_66_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_67_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_67_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_68_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cat_68_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_02_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_03_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_04_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_05_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_06_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_07_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_08_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_09_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_10_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_11_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_12_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_12_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_13_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_14_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_15_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_16_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_17_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_21_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_21_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_22_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_22_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_31_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_32_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_34_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_41_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_42_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_42_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_44_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_45_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_52_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_53_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_61_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_61_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_64_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_65_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_66_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_67_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_alloca_cpy_68_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_01_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_01_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_02_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_02_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_03_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_03_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_04_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_04_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_05_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_05_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_06_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_06_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_07_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_07_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_08_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_08_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_09_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_09_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_10_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_10_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_11_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_11_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_12_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_12_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_13_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_13_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_14_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_14_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_15_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_15_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_16_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_16_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_17_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_18_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_18_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_21_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_21_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_22_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_22_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_31_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_31_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_32_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_32_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_34_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_34_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_41_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_41_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_42_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_42_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_44_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_44_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_45_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_45_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_51_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_51_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_52_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_52_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_53_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_53_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_54_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_54_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_61_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_61_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_63_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_63_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_64_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_64_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_65_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_65_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_66_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_66_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_67_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_67_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_68_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s08---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cat_68_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_01_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_01_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_02_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_02_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_02_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_03_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_03_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_03_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_04_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_04_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_05_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_05_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_06_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_06_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_07_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_07_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_08_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_08_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_09_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_09_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_10_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_10_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_11_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_11_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_12_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_12_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_12_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_13_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_13_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_14_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_14_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_15_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_15_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_16_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_16_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_17_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_17_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_18_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_18_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_21_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_21_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_21_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_22_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_22_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_22_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_31_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_31_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_31_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_32_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_32_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_32_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_34_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_34_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_34_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_41_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_41_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_42_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_42_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_42_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_44_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_44_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_45_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_45_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_45_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_51_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_51_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_51_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_52_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_52_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_53_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_53_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_54_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_61_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_61_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_61_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_63_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_63_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_64_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_64_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_64_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_65_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_66_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_66_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_67_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_67_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_67_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_68_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_68_good.i
+++ b/c/Juliet_Test/CWE121_Stack_Based_Buffer_Overflow---s09---CWE121_Stack_Based_Buffer_Overflow__src_char_declare_cpy_68_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_01_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_01_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_02_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_03_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_04_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_05_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_06_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_07_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_08_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_08_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_09_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_10_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_11_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_11_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_12_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_12_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_13_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_14_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_15_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memcpy_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_02_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_03_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_04_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_05_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_06_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_07_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_09_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_10_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_12_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_12_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_13_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_14_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_15_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_16_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_16_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_17_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_17_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_18_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s01---CWE122_Heap_Based_Buffer_Overflow__char_type_overrun_memmove_18_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_01_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_01_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_02_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_02_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_03_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_03_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_04_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_04_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_05_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_05_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_06_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_06_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_07_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_07_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_08_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_08_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_09_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_09_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_10_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_10_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_11_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_11_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_12_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_12_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_13_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_13_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_14_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_14_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_15_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_15_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_17_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_17_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_18_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_21_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_21_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_22_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_22_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_31_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_31_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_32_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_32_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_34_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_34_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_41_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_41_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_42_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_42_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_44_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_44_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_45_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_45_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_51_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_51_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_53_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_53_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_54_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_54_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_61_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_61_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_63_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_64_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_64_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_65_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_66_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_66_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_67_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_67_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_68_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_loop_68_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_02_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_03_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_04_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_04_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_05_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_05_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_06_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_06_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_07_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_07_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_08_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_08_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_09_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_09_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_10_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_10_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_11_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_11_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_12_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_12_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_13_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_13_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_14_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_14_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_15_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_21_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_21_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_22_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_22_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_42_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_42_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_52_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_53_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_53_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_61_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_61_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_63_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_63_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s05---CWE122_Heap_Based_Buffer_Overflow__CWE131_memcpy_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_01_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_02_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_03_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_04_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_05_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_06_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_07_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_08_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_09_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_10_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_11_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_12_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_12_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_13_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_14_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_15_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_16_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_17_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_18_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_21_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_21_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_22_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_22_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_31_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_32_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_34_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_41_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_41_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_42_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_42_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_44_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_44_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_45_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_51_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_51_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_52_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_61_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_61_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_64_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_65_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_66_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE131_memmove_68_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_01_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_01_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_02_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_02_good.i
@@ -1546,7 +1546,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1555,7 +1554,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1573,7 +1571,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1609,14 +1606,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1672,15 +1661,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_03_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_03_good.i
@@ -1546,7 +1546,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1555,7 +1554,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1573,7 +1571,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1609,14 +1606,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1672,15 +1661,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_04_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_04_good.i
@@ -1568,7 +1568,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1577,7 +1576,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1595,7 +1593,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1631,14 +1628,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1694,15 +1683,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_05_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_05_good.i
@@ -1568,7 +1568,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1577,7 +1576,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1595,7 +1593,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1631,14 +1628,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1694,15 +1683,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_06_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_06_good.i
@@ -1566,7 +1566,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1575,7 +1574,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1593,7 +1591,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1629,14 +1626,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1692,15 +1681,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_07_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_07_good.i
@@ -1566,7 +1566,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1575,7 +1574,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1593,7 +1591,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1629,14 +1626,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1692,15 +1681,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_08_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_08_good.i
@@ -1608,7 +1608,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1617,7 +1616,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1635,7 +1633,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1671,14 +1668,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1734,15 +1723,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_09_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_09_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_10_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_10_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_11_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_11_good.i
@@ -1588,7 +1588,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1597,7 +1596,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1615,7 +1613,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1651,14 +1648,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1714,15 +1703,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_12_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_12_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_13_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_13_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_14_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_14_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_15_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_15_good.i
@@ -1666,7 +1666,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1675,7 +1674,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1693,7 +1691,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1729,14 +1726,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1792,15 +1781,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_16_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_16_good.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_17_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_17_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_18_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_18_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_21_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_21_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_22_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_22_good.i
@@ -1512,7 +1512,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1521,7 +1520,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1539,7 +1537,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1575,14 +1572,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1638,15 +1627,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_31_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_31_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_32_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_32_good.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_34_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_34_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_41_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_41_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_42_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_42_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_44_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_44_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_45_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_45_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_51_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_51_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_52_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_52_good.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_53_bad.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_53_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_54_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_54_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_61_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_61_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_63_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_63_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_64_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_64_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_65_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_65_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_66_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_66_good.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_67_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_67_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_68_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__CWE135_68_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_01_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_01_good.i
@@ -1484,7 +1484,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1493,7 +1492,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1511,7 +1509,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1547,14 +1544,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1610,15 +1599,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_02_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_02_good.i
@@ -1683,7 +1683,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1692,7 +1691,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1710,7 +1708,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1746,14 +1743,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1809,15 +1798,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_03_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_03_good.i
@@ -1683,7 +1683,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1692,7 +1691,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1710,7 +1708,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1746,14 +1743,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1809,15 +1798,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_04_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_04_good.i
@@ -1704,7 +1704,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1713,7 +1712,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1731,7 +1729,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1767,14 +1764,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1830,15 +1819,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_05_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_05_good.i
@@ -1703,7 +1703,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1712,7 +1711,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1730,7 +1728,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1766,14 +1763,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1829,15 +1818,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_06_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_06_good.i
@@ -1702,7 +1702,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1711,7 +1710,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1729,7 +1727,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1765,14 +1762,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1828,15 +1817,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_07_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_07_good.i
@@ -1701,7 +1701,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1710,7 +1709,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1728,7 +1726,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1764,14 +1761,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1827,15 +1816,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_08_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_08_good.i
@@ -1743,7 +1743,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1752,7 +1751,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1770,7 +1768,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1806,14 +1803,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1869,15 +1858,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_09_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_09_good.i
@@ -1700,7 +1700,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1709,7 +1708,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1727,7 +1725,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1763,14 +1760,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1826,15 +1815,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_10_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_10_good.i
@@ -1699,7 +1699,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1708,7 +1707,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1726,7 +1724,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1762,14 +1759,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1825,15 +1814,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_11_bad.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_11_good.i
@@ -1723,7 +1723,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1732,7 +1731,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1750,7 +1748,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1786,14 +1783,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1849,15 +1838,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_12_bad.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_12_good.i
@@ -1674,7 +1674,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1683,7 +1682,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1701,7 +1699,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1737,14 +1734,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1800,15 +1789,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_13_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_13_good.i
@@ -1700,7 +1700,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1709,7 +1708,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1727,7 +1725,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1763,14 +1760,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1826,15 +1815,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_14_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_14_good.i
@@ -1699,7 +1699,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1708,7 +1707,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1726,7 +1724,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1762,14 +1759,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1825,15 +1814,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_15_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_15_good.i
@@ -1803,7 +1803,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1812,7 +1811,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1830,7 +1828,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1866,14 +1863,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1929,15 +1918,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_16_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_16_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_17_bad.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_17_good.i
@@ -1552,7 +1552,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1561,7 +1560,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1579,7 +1577,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1615,14 +1612,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1678,15 +1667,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_18_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_18_good.i
@@ -1500,7 +1500,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1509,7 +1508,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1527,7 +1525,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1563,14 +1560,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1626,15 +1615,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_21_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_21_good.i
@@ -1650,7 +1650,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1659,7 +1658,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1677,7 +1675,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1713,14 +1710,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1776,15 +1765,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_22_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_22_good.i
@@ -1660,7 +1660,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1669,7 +1668,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1687,7 +1685,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1723,14 +1720,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1786,15 +1775,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_31_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_31_good.i
@@ -1496,7 +1496,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1505,7 +1504,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1523,7 +1521,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1559,14 +1556,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1622,15 +1611,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_32_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_32_good.i
@@ -1512,7 +1512,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1521,7 +1520,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1539,7 +1537,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1575,14 +1572,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1638,15 +1627,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_34_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_34_good.i
@@ -1505,7 +1505,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1514,7 +1513,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1532,7 +1530,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1568,14 +1565,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1631,15 +1620,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_41_bad.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_41_good.i
@@ -1498,7 +1498,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1507,7 +1506,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1525,7 +1523,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1561,14 +1558,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1624,15 +1613,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_42_bad.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_42_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_44_bad.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_44_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_45_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_45_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_51_bad.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_51_good.i
@@ -1498,7 +1498,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1507,7 +1506,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1525,7 +1523,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1561,14 +1558,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1624,15 +1613,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_52_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_52_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_53_bad.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_53_good.i
@@ -1540,7 +1540,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1549,7 +1548,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1567,7 +1565,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1603,14 +1600,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1666,15 +1655,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_54_bad.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_54_good.i
@@ -1558,7 +1558,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1567,7 +1566,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1585,7 +1583,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1621,14 +1618,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1684,15 +1673,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_61_bad.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_61_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_63_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_63_good.i
@@ -1512,7 +1512,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1521,7 +1520,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1539,7 +1537,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1575,14 +1572,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1638,15 +1627,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_64_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_64_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_65_bad.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_65_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_66_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_66_good.i
@@ -1512,7 +1512,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1521,7 +1520,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1539,7 +1537,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1575,14 +1572,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1638,15 +1627,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_67_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_67_good.i
@@ -1518,7 +1518,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1527,7 +1526,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1545,7 +1543,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1581,14 +1578,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1644,15 +1633,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_68_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_connect_socket_68_good.i
@@ -1522,7 +1522,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1531,7 +1530,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1549,7 +1547,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1585,14 +1582,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1648,15 +1637,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_02_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_02_good.i
@@ -1616,7 +1616,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1625,7 +1624,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1643,7 +1641,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1679,14 +1676,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1742,15 +1731,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_03_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_03_good.i
@@ -1616,7 +1616,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1625,7 +1624,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1643,7 +1641,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1679,14 +1676,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1742,15 +1731,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_04_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_04_good.i
@@ -1637,7 +1637,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1646,7 +1645,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1664,7 +1662,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1700,14 +1697,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1763,15 +1752,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_05_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_05_good.i
@@ -1636,7 +1636,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1645,7 +1644,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1663,7 +1661,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1699,14 +1696,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1762,15 +1751,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_06_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_06_good.i
@@ -1635,7 +1635,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1644,7 +1643,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1662,7 +1660,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1698,14 +1695,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1761,15 +1750,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_07_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_07_good.i
@@ -1634,7 +1634,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1643,7 +1642,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1661,7 +1659,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1697,14 +1694,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1760,15 +1749,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_08_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_08_good.i
@@ -1676,7 +1676,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1685,7 +1684,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1703,7 +1701,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1739,14 +1736,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1802,15 +1791,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_09_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_09_good.i
@@ -1633,7 +1633,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1642,7 +1641,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1660,7 +1658,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1696,14 +1693,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1759,15 +1748,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_10_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_10_good.i
@@ -1632,7 +1632,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1641,7 +1640,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1659,7 +1657,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1695,14 +1692,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1758,15 +1747,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_11_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_11_good.i
@@ -1656,7 +1656,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1665,7 +1664,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1683,7 +1681,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1719,14 +1716,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1782,15 +1771,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_12_bad.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_12_good.i
@@ -1607,7 +1607,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1616,7 +1615,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1634,7 +1632,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1670,14 +1667,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1733,15 +1722,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_13_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_13_good.i
@@ -1633,7 +1633,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1642,7 +1641,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1660,7 +1658,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1696,14 +1693,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1759,15 +1748,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_14_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_14_good.i
@@ -1632,7 +1632,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1641,7 +1640,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1659,7 +1657,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1695,14 +1692,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1758,15 +1747,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_15_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_15_good.i
@@ -1736,7 +1736,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1745,7 +1744,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1763,7 +1761,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1799,14 +1796,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1862,15 +1851,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_16_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_16_good.i
@@ -1480,7 +1480,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1489,7 +1488,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1507,7 +1505,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1543,14 +1540,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1606,15 +1595,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_17_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_17_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_18_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_18_good.i
@@ -1464,7 +1464,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1473,7 +1472,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1491,7 +1489,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1527,14 +1524,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1590,15 +1579,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_21_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_21_good.i
@@ -1583,7 +1583,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1592,7 +1591,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1610,7 +1608,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1646,14 +1643,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1709,15 +1698,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_22_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_22_good.i
@@ -1593,7 +1593,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1602,7 +1601,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1620,7 +1618,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1656,14 +1653,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1719,15 +1708,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_31_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_31_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_32_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_32_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_34_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_34_good.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_41_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_41_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_42_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_42_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_44_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_44_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_45_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_45_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_51_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_51_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_52_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_52_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_53_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_53_good.i
@@ -1504,7 +1504,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1513,7 +1512,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1531,7 +1529,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1567,14 +1564,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1630,15 +1619,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_54_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_54_good.i
@@ -1528,7 +1528,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1537,7 +1536,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1555,7 +1553,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1591,14 +1588,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1654,15 +1643,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_61_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_61_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_63_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_63_good.i
@@ -1470,7 +1470,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1479,7 +1478,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1497,7 +1495,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1533,14 +1530,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1596,15 +1585,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_64_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_64_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_65_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_65_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_66_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_66_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_67_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_67_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_68_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_68_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_01_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_01_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_02_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_02_good.i
@@ -1593,7 +1593,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1602,7 +1601,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1620,7 +1618,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1656,14 +1653,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1719,15 +1708,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_03_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_03_good.i
@@ -1593,7 +1593,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1602,7 +1601,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1620,7 +1618,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1656,14 +1653,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1719,15 +1708,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_04_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_04_good.i
@@ -1612,7 +1612,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1621,7 +1620,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1639,7 +1637,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1675,14 +1672,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1738,15 +1727,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_05_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_05_good.i
@@ -1611,7 +1611,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1620,7 +1619,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1638,7 +1636,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1674,14 +1671,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1737,15 +1726,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_06_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_06_good.i
@@ -1610,7 +1610,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1619,7 +1618,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1637,7 +1635,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1673,14 +1670,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1736,15 +1725,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_07_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_07_good.i
@@ -1609,7 +1609,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1618,7 +1617,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1636,7 +1634,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1672,14 +1669,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1735,15 +1724,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_08_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_08_good.i
@@ -1651,7 +1651,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1660,7 +1659,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1678,7 +1676,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1714,14 +1711,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1777,15 +1766,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_09_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_09_good.i
@@ -1608,7 +1608,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1617,7 +1616,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1635,7 +1633,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1671,14 +1668,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1734,15 +1723,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_10_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_10_good.i
@@ -1607,7 +1607,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1616,7 +1615,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1634,7 +1632,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1670,14 +1667,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1733,15 +1722,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_11_bad.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_11_good.i
@@ -1631,7 +1631,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1640,7 +1639,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1658,7 +1656,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1694,14 +1691,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1757,15 +1746,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_12_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_12_good.i
@@ -1583,7 +1583,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1592,7 +1591,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1610,7 +1608,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1646,14 +1643,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1709,15 +1698,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_13_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_13_good.i
@@ -1608,7 +1608,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1617,7 +1616,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1635,7 +1633,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1671,14 +1668,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1734,15 +1723,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_14_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_14_good.i
@@ -1607,7 +1607,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1616,7 +1615,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1634,7 +1632,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1670,14 +1667,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1733,15 +1722,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_15_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_15_good.i
@@ -1713,7 +1713,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1722,7 +1721,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1740,7 +1738,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1776,14 +1773,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1839,15 +1828,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_16_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_16_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_17_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_17_good.i
@@ -1503,7 +1503,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1512,7 +1511,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1530,7 +1528,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1566,14 +1563,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1629,15 +1618,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_18_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_18_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_21_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_21_good.i
@@ -1560,7 +1560,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1569,7 +1568,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1587,7 +1585,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1623,14 +1620,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1686,15 +1675,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_22_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_22_good.i
@@ -1570,7 +1570,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1579,7 +1578,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1597,7 +1595,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1633,14 +1630,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1696,15 +1685,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_31_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_31_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_32_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_32_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_34_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_34_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_41_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_41_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_42_bad.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_42_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_44_bad.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_44_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_45_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_45_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_51_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_51_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_52_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_52_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_53_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_53_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_54_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_54_good.i
@@ -1509,7 +1509,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1518,7 +1517,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1536,7 +1534,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1572,14 +1569,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1635,15 +1624,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_61_bad.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_61_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_63_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_63_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_64_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_64_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_65_bad.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_65_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_66_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_66_good.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_67_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_67_good.i
@@ -1475,7 +1475,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1484,7 +1483,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1502,7 +1500,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1538,14 +1535,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1601,15 +1590,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_68_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fscanf_68_good.i
@@ -1473,7 +1473,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1482,7 +1481,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1500,7 +1498,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1536,14 +1533,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1599,15 +1588,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_01_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_01_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_02_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_02_good.i
@@ -1539,7 +1539,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1548,7 +1547,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1566,7 +1564,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1602,14 +1599,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1665,15 +1654,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_03_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_03_good.i
@@ -1539,7 +1539,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1548,7 +1547,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1566,7 +1564,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1602,14 +1599,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1665,15 +1654,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_04_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_04_good.i
@@ -1558,7 +1558,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1567,7 +1566,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1585,7 +1583,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1621,14 +1618,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1684,15 +1673,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_05_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_05_good.i
@@ -1557,7 +1557,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1566,7 +1565,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1584,7 +1582,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1620,14 +1617,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1683,15 +1672,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_06_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_06_good.i
@@ -1556,7 +1556,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1565,7 +1564,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1583,7 +1581,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1619,14 +1616,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1682,15 +1671,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_07_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_07_good.i
@@ -1555,7 +1555,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1564,7 +1563,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1582,7 +1580,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1618,14 +1615,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1681,15 +1670,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_08_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_08_good.i
@@ -1597,7 +1597,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1606,7 +1605,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1624,7 +1622,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1660,14 +1657,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1723,15 +1712,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_09_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_09_good.i
@@ -1554,7 +1554,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1563,7 +1562,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1581,7 +1579,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1617,14 +1614,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1680,15 +1669,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_10_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_10_good.i
@@ -1553,7 +1553,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1562,7 +1561,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1580,7 +1578,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1616,14 +1613,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1679,15 +1668,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_11_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_11_good.i
@@ -1577,7 +1577,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1586,7 +1585,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1604,7 +1602,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1640,14 +1637,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1703,15 +1692,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_12_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_12_good.i
@@ -1529,7 +1529,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1538,7 +1537,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1556,7 +1554,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1592,14 +1589,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1655,15 +1644,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_13_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_13_good.i
@@ -1554,7 +1554,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1563,7 +1562,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1581,7 +1579,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1617,14 +1614,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1680,15 +1669,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_14_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_14_good.i
@@ -1553,7 +1553,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1562,7 +1561,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1580,7 +1578,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1616,14 +1613,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1679,15 +1668,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_15_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_15_good.i
@@ -1659,7 +1659,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1668,7 +1667,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1686,7 +1684,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1722,14 +1719,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1785,15 +1774,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_16_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_16_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_17_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_17_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_18_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_18_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_21_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_21_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_22_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_22_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_31_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_31_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_32_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_32_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_34_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_34_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_41_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_41_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_42_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_42_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_44_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_44_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_45_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_45_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_51_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_51_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_52_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_52_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_53_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_53_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_54_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_54_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_61_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_61_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_63_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_63_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_64_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_64_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_65_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_65_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_66_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_66_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_67_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_67_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_68_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_large_68_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_01_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_01_good.i
@@ -1503,7 +1503,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1512,7 +1511,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1530,7 +1528,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1566,14 +1563,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1629,15 +1618,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_02_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_02_good.i
@@ -1718,7 +1718,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1727,7 +1726,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1745,7 +1743,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1781,14 +1778,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1844,15 +1833,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_03_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_03_good.i
@@ -1718,7 +1718,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1727,7 +1726,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1745,7 +1743,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1781,14 +1778,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1844,15 +1833,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_04_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_04_good.i
@@ -1739,7 +1739,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1748,7 +1747,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1766,7 +1764,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1802,14 +1799,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1865,15 +1854,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_05_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_05_good.i
@@ -1738,7 +1738,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1747,7 +1746,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1765,7 +1763,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1801,14 +1798,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1864,15 +1853,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_06_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_06_good.i
@@ -1737,7 +1737,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1746,7 +1745,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1764,7 +1762,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1800,14 +1797,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1863,15 +1852,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_07_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_07_good.i
@@ -1736,7 +1736,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1745,7 +1744,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1763,7 +1761,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1799,14 +1796,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1862,15 +1851,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_08_bad.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_08_good.i
@@ -1778,7 +1778,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1787,7 +1786,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1805,7 +1803,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1841,14 +1838,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1904,15 +1893,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_09_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_09_good.i
@@ -1735,7 +1735,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1744,7 +1743,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1762,7 +1760,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1798,14 +1795,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1861,15 +1850,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_10_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_10_good.i
@@ -1734,7 +1734,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1743,7 +1742,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1761,7 +1759,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1797,14 +1794,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1860,15 +1849,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_11_bad.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_11_good.i
@@ -1758,7 +1758,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1767,7 +1766,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1785,7 +1783,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1821,14 +1818,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1884,15 +1873,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_12_bad.i
@@ -1490,7 +1490,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1499,7 +1498,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1517,7 +1515,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1553,14 +1550,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1616,15 +1605,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_12_good.i
@@ -1709,7 +1709,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1718,7 +1717,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1736,7 +1734,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1772,14 +1769,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1835,15 +1824,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_13_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_13_good.i
@@ -1735,7 +1735,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1744,7 +1743,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1762,7 +1760,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1798,14 +1795,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1861,15 +1850,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_14_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_14_good.i
@@ -1734,7 +1734,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1743,7 +1742,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1761,7 +1759,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1797,14 +1794,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1860,15 +1849,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_15_bad.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_15_good.i
@@ -1838,7 +1838,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1847,7 +1846,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1865,7 +1863,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1901,14 +1898,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1964,15 +1953,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_16_bad.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_16_good.i
@@ -1535,7 +1535,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1544,7 +1543,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1562,7 +1560,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1598,14 +1595,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1661,15 +1650,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_17_bad.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_17_good.i
@@ -1571,7 +1571,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1580,7 +1579,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1598,7 +1596,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1634,14 +1631,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1697,15 +1686,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_18_bad.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_18_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_21_bad.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_21_good.i
@@ -1685,7 +1685,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1694,7 +1693,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1712,7 +1710,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1748,14 +1745,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1811,15 +1800,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_22_bad.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_22_good.i
@@ -1695,7 +1695,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1704,7 +1703,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1722,7 +1720,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1758,14 +1755,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1821,15 +1810,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_31_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_31_good.i
@@ -1515,7 +1515,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1524,7 +1523,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1542,7 +1540,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1578,14 +1575,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1641,15 +1630,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_32_bad.i
@@ -1429,7 +1429,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1438,7 +1437,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1456,7 +1454,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1492,14 +1489,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1555,15 +1544,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_32_good.i
@@ -1531,7 +1531,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1540,7 +1539,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1558,7 +1556,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1594,14 +1591,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1657,15 +1646,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_34_bad.i
@@ -1429,7 +1429,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1438,7 +1437,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1456,7 +1454,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1492,14 +1489,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1555,15 +1544,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_34_good.i
@@ -1524,7 +1524,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1533,7 +1532,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1551,7 +1549,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1587,14 +1584,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1650,15 +1639,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_41_bad.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_41_good.i
@@ -1517,7 +1517,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1526,7 +1525,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1544,7 +1542,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1580,14 +1577,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1643,15 +1632,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_42_bad.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_42_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_44_bad.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_44_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_45_bad.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_45_good.i
@@ -1533,7 +1533,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1542,7 +1541,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1560,7 +1558,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1596,14 +1593,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1659,15 +1648,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_51_bad.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_51_good.i
@@ -1523,7 +1523,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1532,7 +1531,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1550,7 +1548,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1586,14 +1583,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1649,15 +1638,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_52_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_52_good.i
@@ -1541,7 +1541,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1550,7 +1549,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1568,7 +1566,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1604,14 +1601,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1667,15 +1656,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_53_bad.i
@@ -1440,7 +1440,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1449,7 +1448,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1467,7 +1465,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1503,14 +1500,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1566,15 +1555,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_53_good.i
@@ -1553,7 +1553,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1562,7 +1561,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1580,7 +1578,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1616,14 +1613,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1679,15 +1668,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_54_bad.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_54_good.i
@@ -1583,7 +1583,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1592,7 +1591,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1610,7 +1608,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1646,14 +1643,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1709,15 +1698,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_61_bad.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_61_good.i
@@ -1527,7 +1527,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1536,7 +1535,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1554,7 +1552,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1590,14 +1587,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1653,15 +1642,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_63_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_63_good.i
@@ -1525,7 +1525,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1534,7 +1533,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1552,7 +1550,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1588,14 +1585,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1651,15 +1640,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_64_bad.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_64_good.i
@@ -1535,7 +1535,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1544,7 +1543,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1562,7 +1560,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1598,14 +1595,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1661,15 +1650,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_65_bad.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_65_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_66_bad.i
@@ -1429,7 +1429,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1438,7 +1437,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1456,7 +1454,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1492,14 +1489,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1555,15 +1544,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_66_good.i
@@ -1531,7 +1531,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1540,7 +1539,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1558,7 +1556,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1594,14 +1591,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1657,15 +1646,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_67_bad.i
@@ -1438,7 +1438,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1447,7 +1446,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1465,7 +1463,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1501,14 +1498,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1564,15 +1553,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_67_good.i
@@ -1543,7 +1543,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1552,7 +1551,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1570,7 +1568,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1606,14 +1603,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1669,15 +1658,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_68_bad.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_listen_socket_68_good.i
@@ -1541,7 +1541,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1550,7 +1549,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1568,7 +1566,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1604,14 +1601,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1667,15 +1656,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_01_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_01_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_02_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_02_good.i
@@ -1601,7 +1601,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1610,7 +1609,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1628,7 +1626,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1664,14 +1661,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1727,15 +1716,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_03_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_03_good.i
@@ -1601,7 +1601,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1610,7 +1609,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1628,7 +1626,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1664,14 +1661,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1727,15 +1716,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_04_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_04_good.i
@@ -1626,7 +1626,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1635,7 +1634,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1653,7 +1651,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1689,14 +1686,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1752,15 +1741,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_05_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_05_good.i
@@ -1625,7 +1625,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1634,7 +1633,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1652,7 +1650,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1688,14 +1685,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1751,15 +1740,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_06_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_06_good.i
@@ -1624,7 +1624,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1633,7 +1632,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1651,7 +1649,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1687,14 +1684,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1750,15 +1739,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_07_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_07_good.i
@@ -1623,7 +1623,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1632,7 +1631,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1650,7 +1648,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1686,14 +1683,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1749,15 +1738,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_08_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_08_good.i
@@ -1665,7 +1665,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1674,7 +1673,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1692,7 +1690,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1728,14 +1725,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1791,15 +1780,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_09_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_09_good.i
@@ -1622,7 +1622,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1631,7 +1630,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1649,7 +1647,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1685,14 +1682,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1748,15 +1737,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_10_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_10_good.i
@@ -1621,7 +1621,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1630,7 +1629,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1648,7 +1646,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1684,14 +1681,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1747,15 +1736,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_11_bad.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_11_good.i
@@ -1645,7 +1645,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1654,7 +1653,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1672,7 +1670,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1708,14 +1705,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1771,15 +1760,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_12_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_12_good.i
@@ -1596,7 +1596,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1605,7 +1604,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1623,7 +1621,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1659,14 +1656,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1722,15 +1711,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_13_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_13_good.i
@@ -1622,7 +1622,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1631,7 +1630,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1649,7 +1647,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1685,14 +1682,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1748,15 +1737,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_14_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_14_good.i
@@ -1621,7 +1621,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1630,7 +1629,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1648,7 +1646,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1684,14 +1681,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1747,15 +1736,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_15_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_15_good.i
@@ -1721,7 +1721,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1730,7 +1729,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1748,7 +1746,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1784,14 +1781,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1847,15 +1836,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_16_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_16_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_17_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_17_good.i
@@ -1480,7 +1480,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1489,7 +1488,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1507,7 +1505,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1543,14 +1540,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1606,15 +1595,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_18_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_18_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_21_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_21_good.i
@@ -1568,7 +1568,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1577,7 +1576,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1595,7 +1593,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1631,14 +1628,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1694,15 +1683,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_22_bad.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_22_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_31_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_31_good.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_32_bad.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_32_good.i
@@ -1440,7 +1440,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1449,7 +1448,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1467,7 +1465,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1503,14 +1500,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1566,15 +1555,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_34_bad.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_34_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_41_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_41_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_42_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_42_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_44_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_44_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_45_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_45_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_51_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_51_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_52_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_52_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_53_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_53_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_54_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_54_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_61_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_61_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_63_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_63_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_64_bad.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_64_good.i
@@ -1438,7 +1438,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1447,7 +1446,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1465,7 +1463,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1501,14 +1498,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1564,15 +1553,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_65_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_65_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_66_bad.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_66_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_67_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_67_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_68_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE129_rand_68_good.i
@@ -1450,7 +1450,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1459,7 +1458,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1477,7 +1475,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1513,14 +1510,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1576,15 +1565,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_01_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_01_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_02_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_02_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_03_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_03_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_04_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_04_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_05_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_05_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_06_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_06_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_07_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_07_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_08_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_08_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_09_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_09_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_10_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_10_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_11_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_11_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_12_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_12_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_13_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_13_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_14_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_14_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_15_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_15_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_16_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_16_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_17_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_17_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_18_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_18_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_21_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_21_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_22_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_22_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_31_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_31_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_32_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_32_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_34_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_34_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_41_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_41_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_42_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_42_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_44_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_44_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_45_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_45_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_51_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_51_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_52_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_54_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_54_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_61_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_61_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_63_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_64_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_64_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_65_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_65_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_66_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_66_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_67_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_67_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_68_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_cpy_68_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_01_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_01_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_02_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_02_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_03_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_03_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_04_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_04_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_05_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_05_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_06_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_06_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_07_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_07_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_08_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_08_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_09_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_09_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_10_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_10_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_11_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_11_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_12_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_12_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_13_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_13_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_14_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_14_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_15_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_15_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_16_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_16_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_17_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_17_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_18_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_18_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_21_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_21_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_22_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_22_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_31_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_31_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_32_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_32_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_34_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_34_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_41_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_41_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_42_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_42_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_44_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_44_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_45_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_45_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_51_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_51_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_52_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_52_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_53_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_53_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_54_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_54_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_61_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_61_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_63_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_63_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_64_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_64_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_65_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_65_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_66_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_66_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_67_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_67_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_68_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_loop_68_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_01_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_01_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_02_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_02_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_03_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_03_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_04_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_04_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_05_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_05_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_06_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_06_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_07_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_07_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_08_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_08_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_09_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_09_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_10_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_10_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_11_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_11_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_12_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_12_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_13_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_13_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_14_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_14_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_15_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_16_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_17_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_18_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_21_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_21_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_22_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_22_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_31_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_31_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_32_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_32_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_34_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_34_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_41_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_41_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_42_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_42_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_44_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_44_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_45_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_45_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_51_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_51_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_52_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_52_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_53_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_53_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_54_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_54_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_61_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_61_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_63_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_63_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_64_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_64_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_65_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_65_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_66_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_66_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_67_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_67_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_68_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s06---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memcpy_68_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_01_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_01_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_02_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_02_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_03_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_03_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_04_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_04_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_05_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_05_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_06_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_06_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_07_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_07_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_08_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_08_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_09_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_09_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_10_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_10_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_11_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_11_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_12_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_12_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_13_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_13_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_14_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_14_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_15_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_15_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_16_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_16_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_17_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_17_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_18_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_18_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_21_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_21_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_22_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_22_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_31_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_31_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_32_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_32_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_34_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_34_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_41_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_41_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_42_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_42_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_44_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_44_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_45_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_45_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_51_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_51_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_52_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_52_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_53_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_53_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_54_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_54_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_61_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_61_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_63_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_63_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_64_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_64_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_65_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_65_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_66_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_66_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_67_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_67_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_68_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_memmove_68_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_01_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_01_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_02_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_02_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_03_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_03_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_04_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_04_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_05_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_05_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_06_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_06_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_07_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_07_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_08_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_08_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_09_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_09_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_10_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_10_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_11_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_11_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_12_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_12_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_13_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_13_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_14_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_14_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_15_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_15_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_16_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_16_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_17_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_18_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_18_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_21_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_21_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_22_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_22_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_31_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_31_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_32_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_32_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_34_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_34_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_41_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_41_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_42_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_42_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_44_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_44_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_45_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_45_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_51_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_53_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_54_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_54_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_61_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_61_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_63_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_64_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_64_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_65_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_65_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_66_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_66_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_67_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_67_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_68_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE193_char_ncpy_68_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_01_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_01_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_02_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_02_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_03_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_03_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_04_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_04_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_05_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_05_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_06_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_06_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_07_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_07_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_08_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_08_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_09_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_09_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_10_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_10_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_11_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_11_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_12_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_13_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_13_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_14_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_14_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_15_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_15_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_16_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_16_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_17_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_17_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_18_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_18_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_21_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_21_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_22_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_22_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_31_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_31_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_32_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_32_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_34_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_34_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_41_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_41_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_42_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_42_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_44_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_44_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_45_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_45_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_51_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_51_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_52_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_52_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_53_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_53_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_54_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_54_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_61_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_61_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_63_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_64_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_64_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_65_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_65_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_66_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_67_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_68_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_loop_68_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_02_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_03_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_04_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_04_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_05_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_05_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_06_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_06_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_07_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_07_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_08_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_08_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_09_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_09_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_10_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_10_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_11_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_11_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_12_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_13_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_13_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_14_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_14_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_15_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_21_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_21_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_22_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_22_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_42_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_42_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_52_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_54_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_54_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_61_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_61_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_63_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_65_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memcpy_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_01_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_01_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_02_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_02_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_03_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_03_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_04_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_04_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_05_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_05_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_06_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_06_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_07_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_07_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_08_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_08_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_09_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_09_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_10_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_10_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_11_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_11_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_12_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_12_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_13_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_13_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_14_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_14_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_15_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_15_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_16_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_16_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_17_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_17_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_18_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_18_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_21_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_21_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_22_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_22_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_31_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_31_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_32_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_32_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_34_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_34_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_41_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_41_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_42_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_42_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_44_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_44_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_45_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_45_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_51_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_51_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_52_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_53_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_53_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_54_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_54_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_61_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_61_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_63_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_64_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_64_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_65_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_65_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_66_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_66_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_67_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_67_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_68_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_memmove_68_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_01_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_02_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_02_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_03_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_03_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_04_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_05_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_06_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_07_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_08_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_08_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_09_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_10_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_11_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_11_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_12_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_12_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_13_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_14_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_15_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_21_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_21_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_22_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_22_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_31_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_32_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_34_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_41_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_42_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_42_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_44_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_45_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_53_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_61_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_61_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_63_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_63_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_64_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_67_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncat_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_01_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_02_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_02_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_03_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_03_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_04_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_04_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_05_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_05_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_06_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_06_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_07_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_07_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_08_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_08_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_09_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_09_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_10_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_10_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_11_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_11_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_12_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_12_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_13_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_13_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_14_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_14_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_15_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_15_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_16_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_16_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_17_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_17_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_18_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_18_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_21_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_21_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_22_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_22_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_31_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_31_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_32_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_32_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_34_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_34_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_41_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_41_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_42_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_42_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_44_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_44_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_45_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_45_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_51_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_51_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_52_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_52_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_53_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_53_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_54_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_54_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_61_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_61_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_63_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_63_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_64_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_64_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_65_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_65_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_66_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_66_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_67_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_67_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_68_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s07---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_ncpy_68_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_01_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_02_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_02_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_03_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_03_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_04_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_05_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_06_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_07_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_08_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_08_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_09_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_10_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_11_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_11_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_12_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_12_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_13_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_14_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_15_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_21_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_21_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_22_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_22_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_31_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_32_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_34_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_41_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_42_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_42_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_44_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_45_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_52_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_52_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_61_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_61_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_63_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_63_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_64_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_64_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_66_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_66_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_67_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_char_snprintf_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_01_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_02_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_03_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_04_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_04_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_05_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_05_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_06_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_06_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_07_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_07_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_08_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_09_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_09_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_10_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_10_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_11_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_12_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_12_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_13_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_13_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_14_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_14_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_15_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_15_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_16_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_16_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_17_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_17_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_18_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_18_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_21_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_21_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_22_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_22_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_31_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_31_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_32_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_32_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_34_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_34_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_41_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_41_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_42_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_42_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_44_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_44_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_45_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_45_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_51_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_51_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_52_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_52_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_53_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_54_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_54_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_61_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_61_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_63_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_63_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_64_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_64_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_65_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_65_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_66_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_66_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_67_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_67_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_68_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_loop_68_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_02_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_03_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_04_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_04_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_05_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_05_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_06_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_06_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_07_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_07_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_08_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_08_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_09_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_09_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_10_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_10_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_11_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_11_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_12_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_12_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_13_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_13_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_14_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_14_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_15_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_21_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_21_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_22_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_22_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_42_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_42_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_53_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_61_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_61_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_63_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_64_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_67_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memcpy_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_01_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_02_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_03_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_04_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_05_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_06_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_07_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_08_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_09_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_10_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_11_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_12_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_12_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_13_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_14_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_15_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_16_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_17_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_18_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_21_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_21_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_22_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_22_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_31_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_32_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_34_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_41_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_41_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_42_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_42_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_44_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_44_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_45_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_51_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_51_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_52_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_52_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_53_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_61_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_61_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_63_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_65_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_66_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int64_t_memmove_68_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_01_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_02_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_03_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_04_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_04_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_05_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_05_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_06_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_06_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_07_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_07_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_08_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_09_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_09_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_10_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_10_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_11_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_12_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_12_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_13_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_13_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_14_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_14_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_15_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_15_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_16_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_16_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_17_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_17_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_18_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_18_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_21_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_21_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_22_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_22_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_31_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_31_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_32_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_32_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_34_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_34_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_41_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_41_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_42_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_42_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_44_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_44_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_45_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_45_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_51_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_51_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_52_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_52_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_53_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_54_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_54_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_61_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_61_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_63_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_63_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_64_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_64_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_65_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_65_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_66_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_66_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_67_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_67_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_68_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_loop_68_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_02_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_03_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_04_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_04_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_05_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_05_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_06_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_06_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_07_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_07_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_08_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_08_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_09_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_09_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_10_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_10_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_11_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_11_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_12_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_12_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_13_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_13_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_14_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_14_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_15_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_21_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_21_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_22_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_22_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_42_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_42_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_51_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_51_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_52_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_61_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_61_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_63_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_65_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_67_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memcpy_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_01_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_02_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_03_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_04_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_05_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_06_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_07_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_08_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_09_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_10_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_11_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_12_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_12_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_13_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_14_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_15_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_16_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_17_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_18_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_21_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_21_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_22_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_22_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_31_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_32_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_34_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_41_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_41_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_42_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_42_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_44_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_44_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_45_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_51_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_51_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_52_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_53_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_54_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_61_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_61_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_63_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_64_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_65_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_66_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_67_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_int_memmove_68_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_01_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_01_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_02_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_02_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_03_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_03_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_04_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_04_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_05_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_05_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_06_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_06_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_07_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_07_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_08_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_08_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_09_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_09_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_10_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_10_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_11_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_11_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_12_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_12_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_13_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_13_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_14_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_14_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_15_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_15_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_16_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_16_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_17_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_17_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_18_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_18_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_21_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_21_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_22_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_22_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_31_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_31_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_32_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_32_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_34_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_34_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_41_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_41_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_42_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_42_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_44_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_44_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_45_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_45_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_51_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_51_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_52_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_52_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_53_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_53_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_54_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_54_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_61_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_61_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_63_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_63_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_64_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_64_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_65_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_65_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_66_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_66_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_67_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_67_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_68_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_loop_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_01_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_01_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_02_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_02_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_03_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_03_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_04_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_05_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_06_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_07_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_08_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_09_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_10_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_11_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_12_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_12_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_13_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_14_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_15_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_16_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_17_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_18_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_18_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_21_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_21_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_22_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_22_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_31_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_31_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_32_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_32_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_34_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_34_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_41_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_41_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_42_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_42_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_44_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_44_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_45_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_45_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_52_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_52_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_53_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_61_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_61_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_63_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_63_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_64_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_64_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_65_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_65_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_66_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_66_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_67_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_67_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_68_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memcpy_68_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_02_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_03_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_04_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_05_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_06_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_07_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_08_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_09_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_10_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_11_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_12_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_12_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_13_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_14_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_15_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_21_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_21_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_22_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_22_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_42_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_53_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_53_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_61_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_61_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_64_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_64_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_65_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_65_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_67_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_67_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s08---CWE122_Heap_Based_Buffer_Overflow__c_CWE805_struct_memmove_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_01_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_01_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_02_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_02_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_03_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_03_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_04_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_04_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_05_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_05_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_06_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_06_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_07_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_07_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_08_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_08_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_09_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_09_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_10_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_10_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_11_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_11_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_12_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_12_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_13_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_13_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_14_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_14_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_15_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_15_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_16_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_16_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_17_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_17_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_18_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_18_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_21_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_21_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_22_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_22_good.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_31_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_31_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_32_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_32_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_34_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_34_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_41_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_41_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_42_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_42_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_44_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_44_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_45_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_45_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_51_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_51_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_52_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_52_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_53_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_53_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_54_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_54_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_61_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_61_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_63_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_64_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_64_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_65_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_65_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_66_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_66_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_67_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_67_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_68_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_loop_68_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_02_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_03_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_04_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_05_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_06_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_07_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_08_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_09_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_10_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_11_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_12_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_13_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_14_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_15_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_21_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_21_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_22_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_22_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_42_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_52_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_52_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_53_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_54_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_54_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_61_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_61_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_64_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_64_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_67_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_67_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memcpy_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_01_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_01_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_02_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_02_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_03_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_03_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_04_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_04_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_05_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_05_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_06_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_06_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_07_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_07_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_08_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_08_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_09_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_09_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_10_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_10_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_11_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_11_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_12_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_12_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_13_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_13_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_14_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_14_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_15_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_15_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_16_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_16_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_17_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_17_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_18_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_21_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_21_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_22_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_22_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_31_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_31_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_32_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_32_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_34_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_34_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_41_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_42_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_42_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_44_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_45_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_45_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_52_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_52_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_53_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_53_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_61_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_61_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_63_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_64_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_64_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_66_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_66_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_68_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_memmove_68_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_01_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_01_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_02_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_02_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_03_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_03_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_04_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_04_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_05_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_05_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_06_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_06_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_07_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_07_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_08_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_08_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_09_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_09_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_10_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_10_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_11_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_11_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_12_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_12_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_13_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_13_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_14_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_14_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_15_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_15_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_16_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_16_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_17_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_17_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_18_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_21_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_21_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_22_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_22_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_31_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_31_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_32_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_32_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_34_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_34_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_41_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_42_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_42_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_44_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_45_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_45_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_53_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_61_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_61_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_63_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_63_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_64_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_64_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_66_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_66_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_68_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncat_68_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_01_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_01_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_02_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_02_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_03_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_03_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_04_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_04_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_05_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_05_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_06_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_06_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_07_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_07_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_08_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_08_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_09_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_09_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_10_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_10_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_11_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_11_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_12_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_12_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_13_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_13_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_14_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_14_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_15_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_15_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_16_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_16_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_17_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_17_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_18_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_18_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_21_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_21_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_22_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_22_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_31_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_31_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_32_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_32_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_34_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_34_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_41_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_41_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_42_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_42_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_44_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_44_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_45_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_51_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_51_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_52_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_52_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_53_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_53_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_54_bad.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_54_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_61_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_61_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_63_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_63_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_64_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_64_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_65_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_65_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_66_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_66_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_67_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_67_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_68_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_ncpy_68_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_01_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_01_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_02_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_03_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_04_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_05_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_05_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_06_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_07_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_07_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_08_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_08_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_09_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_10_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_10_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_11_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_11_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_12_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_12_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_13_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_14_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_14_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_15_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_15_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_16_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_16_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_17_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_17_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_18_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_18_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_21_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_21_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_22_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_22_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_31_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_32_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_32_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_34_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_41_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_42_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_42_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_44_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_45_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_45_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_51_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_52_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_53_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_53_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_54_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_61_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_61_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_63_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_63_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_64_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_64_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_65_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_66_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_66_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_67_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_67_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_68_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s09---CWE122_Heap_Based_Buffer_Overflow__c_CWE806_char_snprintf_68_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_01_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_02_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_02_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_03_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_03_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_04_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_05_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_06_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_07_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_08_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_08_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_09_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_10_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_11_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_11_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_12_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_12_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_13_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_14_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_15_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_21_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_21_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_22_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_22_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_31_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_32_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_34_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_41_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_42_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_42_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_44_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_45_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_61_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_61_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_63_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_63_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_64_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_67_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cat_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_01_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_01_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_02_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_02_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_03_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_03_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_04_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_04_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_05_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_05_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_06_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_06_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_07_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_07_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_08_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_08_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_09_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_09_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_10_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_10_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_11_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_11_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_12_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_12_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_13_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_13_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_14_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_14_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_15_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_15_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_16_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_16_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_17_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_17_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_18_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_18_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_21_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_21_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_22_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_22_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_31_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_31_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_32_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_32_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_34_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_34_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_41_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_41_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_42_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_42_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_44_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_44_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_45_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_45_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_51_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_51_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_52_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_52_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_53_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_53_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_54_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_54_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_61_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_61_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_63_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_64_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_64_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_65_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_65_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_66_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_66_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_67_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_68_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_dest_char_cpy_68_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_01_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_04_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_04_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_05_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_05_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_06_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_06_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_07_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_07_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_08_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_08_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_09_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_09_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_10_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_10_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_11_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_11_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_12_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_12_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_13_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_13_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_14_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_14_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_15_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_16_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_17_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_21_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_21_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_22_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_22_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_31_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_32_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_34_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_41_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_42_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_42_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_44_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_54_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_54_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_61_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_61_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_63_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_63_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_64_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_66_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_67_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cat_68_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_01_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_01_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_02_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_02_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_03_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_03_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_04_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_04_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_05_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_05_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_06_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_06_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_07_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_07_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_08_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_08_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_09_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_09_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_10_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_10_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_11_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_11_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_12_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_12_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_13_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_13_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_14_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_14_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_15_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_16_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_17_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_18_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_21_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_21_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_22_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_22_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_31_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_31_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_32_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_32_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_34_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_34_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_41_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_41_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_42_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_42_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_44_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_44_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_45_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_45_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_51_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_51_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_52_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_52_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_53_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_53_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_54_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_61_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_61_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_63_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_63_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_64_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_64_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_65_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_65_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_66_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_66_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_67_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_67_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_68_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s10---CWE122_Heap_Based_Buffer_Overflow__c_src_char_cpy_68_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_01_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_05_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_07_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_08_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_08_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_10_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_11_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_11_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_12_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_14_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_15_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_15_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_16_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_16_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_17_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_17_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_18_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_18_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_21_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_21_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_22_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_22_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_31_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_32_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_34_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_42_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_42_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_45_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_51_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_51_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_52_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_52_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_53_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_54_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_61_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_61_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_63_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_63_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_64_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_64_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_65_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_66_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_66_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_67_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_double_68_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_01_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_05_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_07_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_08_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_08_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_10_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_11_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_11_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_12_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_14_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_15_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_15_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_16_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_16_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_17_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_17_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_18_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_18_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_21_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_21_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_22_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_22_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_31_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_32_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_34_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_41_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_42_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_42_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_44_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_45_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_51_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_51_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_52_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_53_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_53_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_54_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_61_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_61_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_63_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_63_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_64_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_64_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_65_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_65_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_66_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_66_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_67_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_int64_t_68_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_01_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_01_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_01_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_02_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_02_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_02_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_03_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_03_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_03_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_04_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_04_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_04_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_05_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_05_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_05_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_06_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_06_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_06_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_07_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_07_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_07_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_08_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_08_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_08_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_09_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_09_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_09_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_10_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_10_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_10_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_11_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_11_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_11_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_12_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_12_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_12_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_12_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_13_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_13_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_13_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_14_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_14_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_14_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_15_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_15_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_16_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_16_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_17_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_17_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_18_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_18_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_21_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_21_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_21_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_21_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_22_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_22_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_22_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_22_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_31_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_31_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_31_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_32_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_32_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_32_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_34_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_34_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_34_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_41_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_41_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_42_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_42_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_42_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_42_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_44_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_44_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_45_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_45_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_45_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_51_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_51_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_52_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_52_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_53_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_53_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_54_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_54_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_61_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_61_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_61_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_61_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_63_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_63_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_63_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_63_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_64_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_64_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_64_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_64_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_65_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_65_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_66_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_66_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_66_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_66_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_67_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_67_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_67_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_68_bad.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_68_good.i
+++ b/c/Juliet_Test/CWE122_Heap_Based_Buffer_Overflow---s11---CWE122_Heap_Based_Buffer_Overflow__sizeof_struct_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_01_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_01_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_02_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_02_good.i
@@ -1543,7 +1543,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1552,7 +1551,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1570,7 +1568,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1606,14 +1603,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1669,15 +1658,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_03_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_03_good.i
@@ -1543,7 +1543,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1552,7 +1551,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1570,7 +1568,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1606,14 +1603,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1669,15 +1658,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_04_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_04_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_05_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_05_good.i
@@ -1563,7 +1563,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1572,7 +1571,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1590,7 +1588,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1626,14 +1623,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1689,15 +1678,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_06_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_06_good.i
@@ -1562,7 +1562,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1571,7 +1570,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1589,7 +1587,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1625,14 +1622,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1688,15 +1677,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_07_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_07_good.i
@@ -1561,7 +1561,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1570,7 +1569,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1588,7 +1586,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1624,14 +1621,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1687,15 +1676,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_08_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_08_good.i
@@ -1603,7 +1603,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1612,7 +1611,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1630,7 +1628,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1666,14 +1663,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1729,15 +1718,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_09_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_09_good.i
@@ -1560,7 +1560,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1569,7 +1568,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1587,7 +1585,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1623,14 +1620,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1686,15 +1675,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_10_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_10_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_11_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_11_good.i
@@ -1583,7 +1583,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1592,7 +1591,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1610,7 +1608,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1646,14 +1643,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1709,15 +1698,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_12_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_12_good.i
@@ -1534,7 +1534,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1543,7 +1542,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1561,7 +1559,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1597,14 +1594,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1660,15 +1649,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_13_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_13_good.i
@@ -1560,7 +1560,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1569,7 +1568,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1587,7 +1585,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1623,14 +1620,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1686,15 +1675,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_14_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_14_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_15_bad.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_15_good.i
@@ -1663,7 +1663,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1672,7 +1671,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1690,7 +1688,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1726,14 +1723,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1789,15 +1778,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_16_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_16_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_17_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_17_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_18_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_18_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_21_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_21_good.i
@@ -1545,7 +1545,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1554,7 +1553,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1572,7 +1570,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1608,14 +1605,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1671,15 +1660,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_22_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_22_good.i
@@ -1555,7 +1555,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1564,7 +1563,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1582,7 +1580,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1618,14 +1615,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1681,15 +1670,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_31_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_31_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_32_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_32_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_34_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_34_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_41_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_41_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_42_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_42_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_44_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_44_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_45_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_45_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_51_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_51_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_52_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_52_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_53_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_53_good.i
@@ -1464,7 +1464,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1473,7 +1472,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1491,7 +1489,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1527,14 +1524,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1590,15 +1579,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_54_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_54_good.i
@@ -1494,7 +1494,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1503,7 +1502,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1521,7 +1519,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1557,14 +1554,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1620,15 +1609,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_61_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_61_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_63_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_63_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_64_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_64_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_65_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_65_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_66_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_66_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_67_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_67_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_68_bad.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_connect_socket_68_good.i
@@ -1452,7 +1452,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1461,7 +1460,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1479,7 +1477,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1515,14 +1512,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1578,15 +1567,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_01_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_01_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_02_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_02_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_03_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_03_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_04_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_04_good.i
@@ -1497,7 +1497,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1506,7 +1505,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1524,7 +1522,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1560,14 +1557,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1623,15 +1612,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_05_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_05_good.i
@@ -1496,7 +1496,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1505,7 +1504,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1523,7 +1521,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1559,14 +1556,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1622,15 +1611,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_06_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_06_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_07_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_07_good.i
@@ -1494,7 +1494,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1503,7 +1502,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1521,7 +1519,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1557,14 +1554,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1620,15 +1609,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_08_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_08_good.i
@@ -1536,7 +1536,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1545,7 +1544,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1563,7 +1561,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1599,14 +1596,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1662,15 +1651,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_09_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_09_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_10_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_10_good.i
@@ -1492,7 +1492,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1501,7 +1500,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1519,7 +1517,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1555,14 +1552,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1618,15 +1607,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_11_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_11_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_12_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_12_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_13_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_13_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_14_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_14_good.i
@@ -1492,7 +1492,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1501,7 +1500,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1519,7 +1517,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1555,14 +1552,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1618,15 +1607,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_15_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_15_good.i
@@ -1596,7 +1596,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1605,7 +1604,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1623,7 +1621,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1659,14 +1656,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1722,15 +1711,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_16_bad.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_16_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_17_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_17_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_18_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_18_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_21_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_21_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_22_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_22_good.i
@@ -1488,7 +1488,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1497,7 +1496,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1515,7 +1513,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1551,14 +1548,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1614,15 +1603,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_31_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_31_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_32_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_32_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_34_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_34_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_41_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_41_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_42_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_42_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_44_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_44_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_45_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_45_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_51_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_51_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_52_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_52_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_53_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_53_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_54_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_54_good.i
@@ -1452,7 +1452,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1461,7 +1460,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1479,7 +1477,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1515,14 +1512,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1578,15 +1567,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_61_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_61_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_63_bad.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_63_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_64_bad.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_64_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_65_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_65_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_66_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_66_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_67_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_67_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_68_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fgets_68_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_01_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_01_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_02_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_02_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_03_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_03_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_04_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_04_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_05_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_05_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_06_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_06_good.i
@@ -1470,7 +1470,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1479,7 +1478,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1497,7 +1495,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1533,14 +1530,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1596,15 +1585,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_07_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_07_good.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_08_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_08_good.i
@@ -1511,7 +1511,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1520,7 +1519,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1538,7 +1536,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1574,14 +1571,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1637,15 +1626,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_09_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_09_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_10_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_10_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_11_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_11_good.i
@@ -1491,7 +1491,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1500,7 +1499,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1518,7 +1516,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1554,14 +1551,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1617,15 +1606,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_12_bad.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_12_good.i
@@ -1443,7 +1443,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1452,7 +1451,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1470,7 +1468,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1506,14 +1503,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1569,15 +1558,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_13_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_13_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_14_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_14_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_15_bad.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_15_good.i
@@ -1573,7 +1573,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1582,7 +1581,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1600,7 +1598,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1636,14 +1633,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1699,15 +1688,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_16_bad.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_16_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_17_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_17_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_18_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_18_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_21_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_21_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_22_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_22_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_31_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_31_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_32_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_32_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_34_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_34_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_41_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_41_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_42_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_42_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_44_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_44_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_45_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_45_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_51_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_51_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_52_bad.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_52_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_53_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_53_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_54_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_54_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_61_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_61_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_63_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_63_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_64_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_64_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_65_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_65_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_66_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_66_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_67_bad.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_67_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_68_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_fscanf_68_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_01_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_01_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_02_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_02_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_03_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_03_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_04_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_04_good.i
@@ -1599,7 +1599,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1608,7 +1607,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1626,7 +1624,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1662,14 +1659,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1725,15 +1714,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_05_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_05_good.i
@@ -1598,7 +1598,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1607,7 +1606,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1625,7 +1623,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1661,14 +1658,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1724,15 +1713,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_06_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_06_good.i
@@ -1597,7 +1597,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1606,7 +1605,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1624,7 +1622,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1660,14 +1657,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1723,15 +1712,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_07_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_07_good.i
@@ -1596,7 +1596,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1605,7 +1604,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1623,7 +1621,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1659,14 +1656,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1722,15 +1711,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_08_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_08_good.i
@@ -1638,7 +1638,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1647,7 +1646,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1665,7 +1663,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1701,14 +1698,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1764,15 +1753,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_09_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_09_good.i
@@ -1595,7 +1595,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1604,7 +1603,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1622,7 +1620,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1658,14 +1655,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1721,15 +1710,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_10_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_10_good.i
@@ -1594,7 +1594,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1603,7 +1602,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1621,7 +1619,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1657,14 +1654,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1720,15 +1709,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_11_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_11_good.i
@@ -1618,7 +1618,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1627,7 +1626,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1645,7 +1643,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1681,14 +1678,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1744,15 +1733,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_12_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_12_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_13_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_13_good.i
@@ -1595,7 +1595,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1604,7 +1603,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1622,7 +1620,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1658,14 +1655,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1721,15 +1710,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_14_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_14_good.i
@@ -1594,7 +1594,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1603,7 +1602,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1621,7 +1619,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1657,14 +1654,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1720,15 +1709,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_15_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_15_good.i
@@ -1698,7 +1698,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1707,7 +1706,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1725,7 +1723,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1761,14 +1758,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1824,15 +1813,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_16_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_16_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_17_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_17_good.i
@@ -1501,7 +1501,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1510,7 +1509,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1528,7 +1526,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1564,14 +1561,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1627,15 +1616,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_18_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_18_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_21_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_21_good.i
@@ -1580,7 +1580,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1589,7 +1588,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1607,7 +1605,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1643,14 +1640,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1706,15 +1695,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_22_bad.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_22_good.i
@@ -1590,7 +1590,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1599,7 +1598,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1617,7 +1615,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1653,14 +1650,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1716,15 +1705,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_31_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_31_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_32_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_32_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_34_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_34_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_41_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_41_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_42_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_42_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_44_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_44_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_45_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_45_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_51_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_51_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_52_bad.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_52_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_53_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_53_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_54_bad.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_54_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_61_bad.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_61_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_63_bad.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_63_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_64_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_64_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_65_bad.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_65_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_66_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_66_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_67_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_67_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_68_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__CWE839_listen_socket_68_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_01_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_02_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_03_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_04_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_04_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_05_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_06_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_06_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_07_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_08_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_09_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_09_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_10_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_11_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_12_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_12_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_13_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_13_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_14_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_15_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_16_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_17_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_31_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_32_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_34_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_41_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_44_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_52_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_52_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_64_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_65_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_66_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_67_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_cpy_68_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_01_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_02_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_03_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_04_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_05_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_06_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_07_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_08_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_08_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_09_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_10_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_11_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_11_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_12_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_12_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_13_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_14_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_15_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_16_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_16_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_17_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_18_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_31_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_32_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_34_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_41_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_45_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_51_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_53_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_64_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_67_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_68_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_loop_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_01_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_02_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_03_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_04_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_05_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_06_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_07_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_08_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_09_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_10_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_11_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_12_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_13_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_14_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_15_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_16_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_17_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_18_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_31_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_32_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_34_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_41_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_41_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_44_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_44_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_45_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_54_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_54_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_63_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_64_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_66_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memcpy_68_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_04_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_04_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_05_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_05_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_06_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_06_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_07_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_07_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_08_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_08_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_09_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_09_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_10_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_10_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_11_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_11_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_12_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_13_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_13_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_14_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_14_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_15_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_63_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_63_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_67_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_memmove_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_02_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_03_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_04_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_04_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_05_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_05_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_06_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_06_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_07_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_07_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_08_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_09_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_09_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_10_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_10_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_11_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_12_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_13_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_13_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_14_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_14_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_15_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_15_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_16_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_17_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_18_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_41_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_44_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_52_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_54_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_65_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_67_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_67_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_68_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_alloca_ncpy_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_02_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_03_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_04_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_05_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_06_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_07_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_08_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_09_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_10_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_11_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_13_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_14_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_15_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_16_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_17_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_31_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_32_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_34_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_41_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_44_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_45_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_53_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_64_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_66_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_67_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_cpy_68_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_01_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_02_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_02_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_03_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_03_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_04_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_04_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_05_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_06_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_06_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_07_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_08_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_09_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_09_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_10_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_11_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_12_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_12_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_13_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_13_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_14_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_15_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_31_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_32_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_34_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_41_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_44_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_45_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_52_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_52_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_53_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_64_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_64_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_66_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_66_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_67_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_loop_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_02_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_03_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_04_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_04_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_05_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_05_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_06_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_06_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_07_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_07_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_08_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_08_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_09_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_09_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_10_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_10_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_11_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_11_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_12_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_12_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_13_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_13_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_14_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_14_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_15_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_16_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_17_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_18_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_31_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_32_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_34_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_41_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_44_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_45_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_51_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_51_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_52_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_52_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_53_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_53_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_54_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_54_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_63_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_64_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_65_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_65_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_66_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_67_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memcpy_68_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_01_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_02_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_03_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_04_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_06_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_09_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_12_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_13_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_15_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_16_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_17_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_18_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_31_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_32_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_34_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_41_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_41_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_44_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_44_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_45_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_51_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_51_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_52_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_52_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_53_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_53_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_63_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_64_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_65_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_65_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_66_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_67_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_memmove_68_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_01_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_02_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_03_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_04_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_06_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_08_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_09_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_11_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_12_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_12_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_13_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_15_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_15_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_16_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_16_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_17_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_17_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_18_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_18_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_31_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_32_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_34_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_41_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_41_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_44_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_44_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_45_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_52_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_52_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_53_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_54_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_63_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_63_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_64_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_64_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_65_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_65_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_67_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_68_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s01---CWE124_Buffer_Underwrite__char_declare_ncpy_68_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_01_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_02_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_03_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_04_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_05_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_06_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_07_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_08_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_08_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_09_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_10_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_11_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_11_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_12_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_12_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_13_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_14_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_15_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_15_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_16_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_16_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_17_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_18_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_18_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_21_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_21_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_22_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_22_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_31_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_32_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_34_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_41_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_42_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_42_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_44_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_45_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_51_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_52_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_53_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_54_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_61_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_61_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_63_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_63_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_64_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_65_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_66_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_67_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_68_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_negative_68_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_01_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_01_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_02_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_02_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_03_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_03_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_04_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_04_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_05_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_05_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_06_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_06_good.i
@@ -1484,7 +1484,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1493,7 +1492,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1511,7 +1509,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1547,14 +1544,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1610,15 +1599,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_07_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_07_good.i
@@ -1483,7 +1483,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1492,7 +1491,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1510,7 +1508,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1546,14 +1543,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1609,15 +1598,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_08_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_08_good.i
@@ -1525,7 +1525,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1534,7 +1533,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1552,7 +1550,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1588,14 +1585,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1651,15 +1640,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_09_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_09_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_10_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_10_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_11_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_11_good.i
@@ -1505,7 +1505,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1514,7 +1513,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1532,7 +1530,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1568,14 +1565,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1631,15 +1620,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_12_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_12_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_13_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_13_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_14_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_14_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_15_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_15_good.i
@@ -1581,7 +1581,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1590,7 +1589,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1608,7 +1606,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1644,14 +1641,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1707,15 +1696,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_16_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_16_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_17_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_17_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_18_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_18_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_21_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_21_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_22_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_22_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_31_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_31_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_32_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_32_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_34_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_34_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_41_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_41_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_42_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_42_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_44_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_44_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_45_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_45_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_51_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_51_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_52_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_52_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_53_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_53_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_54_bad.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_54_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_61_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_61_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_63_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_63_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_64_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_64_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_65_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_65_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_66_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_66_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_67_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_67_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_68_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__CWE839_rand_68_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_02_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_03_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_04_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_04_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_05_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_05_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_06_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_06_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_07_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_07_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_08_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_08_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_09_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_09_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_10_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_10_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_11_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_11_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_12_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_13_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_13_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_14_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_14_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_15_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_21_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_21_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_22_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_22_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_42_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_53_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_53_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_54_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_54_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_61_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_61_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_64_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_64_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_65_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_65_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_cpy_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_01_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_01_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_02_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_02_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_03_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_03_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_04_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_04_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_05_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_05_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_06_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_06_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_07_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_07_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_08_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_08_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_09_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_09_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_10_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_10_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_11_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_11_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_12_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_12_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_13_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_13_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_14_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_14_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_15_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_15_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_16_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_16_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_17_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_18_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_18_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_21_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_21_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_22_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_22_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_31_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_31_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_32_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_32_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_34_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_34_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_41_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_41_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_42_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_42_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_44_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_44_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_45_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_45_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_51_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_53_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_53_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_54_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_54_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_61_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_61_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_63_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_64_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_64_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_65_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_65_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_66_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_66_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_67_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_67_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_68_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_loop_68_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_01_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_02_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_03_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_04_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_05_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_06_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_07_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_08_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_09_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_10_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_11_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_12_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_12_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_13_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_14_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_15_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_16_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_16_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_17_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_18_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_21_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_22_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_31_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_32_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_34_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_41_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_42_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_42_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_45_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_51_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_61_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_61_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_63_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_64_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_67_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_68_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memcpy_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_01_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_01_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_02_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_02_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_03_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_03_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_04_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_04_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_05_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_05_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_06_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_06_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_07_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_07_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_08_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_08_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_09_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_09_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_10_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_10_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_11_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_11_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_12_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_12_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_13_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_13_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_14_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_14_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_15_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_15_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_17_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_17_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_18_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_21_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_21_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_22_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_22_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_31_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_31_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_32_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_32_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_34_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_34_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_41_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_41_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_42_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_42_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_44_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_44_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_45_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_45_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_51_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_51_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_54_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_54_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_61_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_61_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_63_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_63_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_64_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_65_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_65_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_66_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_66_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_67_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_67_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_68_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_memmove_68_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_01_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_01_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_02_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_02_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_03_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_03_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_04_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_05_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_06_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_07_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_08_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_09_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_10_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_11_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_12_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_12_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_13_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_14_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_15_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_15_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_16_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_16_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_17_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_17_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_18_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_18_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_21_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_21_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_22_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_22_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_31_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_31_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_32_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_32_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_34_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_34_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_41_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_41_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_42_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_42_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_44_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_44_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_45_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_45_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_51_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_51_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_52_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_52_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_53_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_53_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_54_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_54_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_61_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_61_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_63_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_64_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_64_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_65_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_65_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_66_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_67_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_68_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE124_Buffer_Underwrite---s02---CWE124_Buffer_Underwrite__malloc_char_ncpy_68_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_01_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_01_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_02_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_02_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_03_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_03_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_04_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_04_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_05_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_05_good.i
@@ -1475,7 +1475,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1484,7 +1483,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1502,7 +1500,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1538,14 +1535,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1601,15 +1590,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_06_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_06_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_07_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_07_good.i
@@ -1473,7 +1473,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1482,7 +1481,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1500,7 +1498,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1536,14 +1533,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1599,15 +1588,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_08_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_08_good.i
@@ -1515,7 +1515,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1524,7 +1523,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1542,7 +1540,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1578,14 +1575,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1641,15 +1630,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_09_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_09_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_10_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_10_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_11_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_11_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_12_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_12_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_13_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_13_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_14_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_14_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_15_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_15_good.i
@@ -1575,7 +1575,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1584,7 +1583,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1602,7 +1600,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1638,14 +1635,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1701,15 +1690,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_16_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_16_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_17_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_17_good.i
@@ -1438,7 +1438,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1447,7 +1446,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1465,7 +1463,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1501,14 +1498,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1564,15 +1553,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_18_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_18_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_21_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_21_good.i
@@ -1479,7 +1479,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1488,7 +1487,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1506,7 +1504,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1542,14 +1539,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1605,15 +1594,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_22_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_22_good.i
@@ -1489,7 +1489,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1498,7 +1497,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1516,7 +1514,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1552,14 +1549,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1615,15 +1604,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_31_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_31_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_32_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_32_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_34_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_34_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_41_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_41_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_42_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_42_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_44_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_44_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_45_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_45_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_51_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_51_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_52_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_52_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_53_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_53_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_54_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_54_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_61_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_61_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_63_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_63_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_64_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_64_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_65_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_65_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_66_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_66_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_67_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_67_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_68_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_connect_socket_68_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_01_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_01_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_02_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_02_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_03_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_03_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_04_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_04_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_05_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_05_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_06_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_06_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_07_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_07_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_08_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_08_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_09_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_09_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_10_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_10_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_11_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_11_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_12_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_12_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_13_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_13_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_14_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_14_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_15_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_15_good.i
@@ -1508,7 +1508,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1517,7 +1516,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1535,7 +1533,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1571,14 +1568,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1634,15 +1623,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_16_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_16_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_17_bad.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_17_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_18_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_18_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_21_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_21_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_22_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_22_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_31_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_31_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_32_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_32_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_34_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_34_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_41_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_41_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_42_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_42_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_44_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_44_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_45_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_45_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_51_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_51_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_52_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_52_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_53_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_53_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_54_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_54_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_61_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_61_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_63_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_63_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_64_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_64_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_65_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_65_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_66_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_66_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_67_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_67_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_68_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fgets_68_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_01_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_01_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_02_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_02_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_03_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_03_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_04_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_04_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_05_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_05_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_06_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_06_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_07_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_07_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_08_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_08_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_09_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_09_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_10_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_10_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_11_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_11_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_12_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_13_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_13_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_14_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_14_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_15_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_15_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_16_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_16_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_17_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_17_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_18_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_18_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_21_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_21_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_22_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_22_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_31_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_31_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_32_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_32_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_34_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_34_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_41_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_41_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_42_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_42_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_44_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_44_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_45_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_45_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_51_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_51_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_52_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_52_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_53_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_53_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_54_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_54_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_61_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_61_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_63_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_63_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_64_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_64_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_65_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_65_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_66_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_66_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_67_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_67_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_68_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_fscanf_68_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_04_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_04_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_05_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_05_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_06_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_06_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_07_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_07_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_08_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_08_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_09_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_09_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_10_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_10_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_11_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_11_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_12_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_12_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_13_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_13_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_14_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_14_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_15_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_16_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_16_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_17_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_18_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_21_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_21_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_22_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_22_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_31_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_32_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_32_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_34_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_34_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_42_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_42_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_45_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_45_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_51_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_52_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_53_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_53_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_54_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_61_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_61_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_63_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_63_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_64_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_64_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_66_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_66_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_67_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_67_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_68_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_large_68_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_01_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_01_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_02_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_02_good.i
@@ -1490,7 +1490,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1499,7 +1498,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1517,7 +1515,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1553,14 +1550,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1616,15 +1605,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_03_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_03_good.i
@@ -1490,7 +1490,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1499,7 +1498,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1517,7 +1515,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1553,14 +1550,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1616,15 +1605,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_04_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_04_good.i
@@ -1511,7 +1511,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1520,7 +1519,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1538,7 +1536,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1574,14 +1571,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1637,15 +1626,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_05_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_05_good.i
@@ -1510,7 +1510,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1519,7 +1518,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1537,7 +1535,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1573,14 +1570,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1636,15 +1625,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_06_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_06_good.i
@@ -1509,7 +1509,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1518,7 +1517,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1536,7 +1534,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1572,14 +1569,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1635,15 +1624,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_07_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_07_good.i
@@ -1508,7 +1508,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1517,7 +1516,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1535,7 +1533,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1571,14 +1568,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1634,15 +1623,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_08_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_08_good.i
@@ -1550,7 +1550,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1559,7 +1558,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1577,7 +1575,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1613,14 +1610,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1676,15 +1665,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_09_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_09_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_10_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_10_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_11_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_11_good.i
@@ -1530,7 +1530,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1539,7 +1538,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1557,7 +1555,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1593,14 +1590,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1656,15 +1645,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_12_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_12_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_13_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_13_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_14_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_14_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_15_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_15_good.i
@@ -1610,7 +1610,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1619,7 +1618,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1637,7 +1635,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1673,14 +1670,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1736,15 +1725,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_16_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_16_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_17_bad.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_17_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_18_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_18_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_21_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_21_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_22_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_22_good.i
@@ -1524,7 +1524,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1533,7 +1532,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1551,7 +1549,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1587,14 +1584,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1650,15 +1639,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_31_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_31_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_32_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_32_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_34_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_34_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_41_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_41_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_42_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_42_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_44_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_44_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_45_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_45_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_51_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_51_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_52_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_52_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_53_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_53_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_54_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_54_good.i
@@ -1475,7 +1475,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1484,7 +1483,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1502,7 +1500,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1538,14 +1535,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1601,15 +1590,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_61_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_61_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_63_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_63_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_64_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_64_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_65_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_65_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_66_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_66_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_67_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_67_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_68_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_listen_socket_68_good.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_01_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_02_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_03_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_04_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_05_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_06_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_07_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_08_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_09_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_10_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_11_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_12_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_12_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_13_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_14_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_15_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_15_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_16_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_17_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_18_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_21_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_22_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_31_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_32_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_34_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_41_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_42_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_42_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_44_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_45_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_51_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_52_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_53_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_54_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_54_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_61_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_61_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_63_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_64_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_65_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_66_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_67_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_68_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE129_rand_68_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_01_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_02_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_03_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_04_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_04_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_05_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_05_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_06_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_06_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_07_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_07_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_08_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_08_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_09_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_09_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_10_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_10_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_11_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_11_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_12_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_13_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_13_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_14_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_14_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_15_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_15_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_16_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_17_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_17_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_18_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_loop_18_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_01_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_02_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_03_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_04_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_04_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_05_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_05_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_06_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_06_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_07_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_07_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_08_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_08_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_09_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_09_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_10_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_10_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_11_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_11_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_12_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_13_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_13_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_14_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_14_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_15_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_15_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_16_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_16_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_17_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_17_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_18_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_memcpy_18_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_02_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_03_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_04_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_05_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_06_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_07_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_08_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_08_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_09_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_10_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_11_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_11_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_12_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_12_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_13_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_14_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_15_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_16_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_17_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__CWE170_char_strncpy_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_01_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_01_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_02_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_02_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_03_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_03_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_04_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_04_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_05_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_06_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_06_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_07_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_08_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_08_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_09_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_09_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_10_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_11_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_11_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_12_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_12_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_13_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_13_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_14_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_15_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_15_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_16_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_16_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_17_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_17_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_18_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_18_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_31_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_31_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_32_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_32_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_34_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_34_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_41_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_41_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_44_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_45_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_45_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_51_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_51_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_52_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_52_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_53_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_53_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_54_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_54_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_63_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_63_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_64_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_65_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_65_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_66_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_66_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_67_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_67_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_68_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_loop_68_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_01_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_01_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_02_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_02_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_03_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_03_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_04_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_04_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_05_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_05_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_06_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_06_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_07_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_07_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_08_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_08_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_09_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_09_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_10_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_10_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_11_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_11_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_12_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_12_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_13_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_13_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_14_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_14_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_15_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_15_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_16_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_16_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_17_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_17_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_18_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_18_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_31_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_31_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_32_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_32_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_34_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_34_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_41_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_41_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_44_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_44_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_45_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_45_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_51_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_51_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_52_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_52_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_53_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_53_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_54_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_54_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_63_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_63_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_64_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_64_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_65_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_65_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_66_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_66_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_67_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_68_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memcpy_68_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_01_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_02_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_02_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_03_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_03_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_04_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_04_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_05_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_05_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_06_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_06_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_07_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_07_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_08_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_08_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_09_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_09_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_10_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_10_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_11_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_11_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_12_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_12_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_13_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_13_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_14_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_14_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_15_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_15_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_16_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_18_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_31_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_32_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_34_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_41_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_41_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_44_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_44_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_45_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_51_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_51_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_52_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_52_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_53_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_53_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_54_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_54_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_63_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_64_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_64_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_65_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_65_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_66_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_67_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_68_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_alloca_memmove_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_01_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_01_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_02_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_02_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_03_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_03_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_04_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_04_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_05_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_05_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_06_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_06_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_07_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_07_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_08_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_08_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_09_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_09_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_10_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_10_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_11_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_11_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_12_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_13_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_13_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_14_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_14_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_15_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_15_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_16_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_16_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_17_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_17_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_18_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_18_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_31_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_31_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_32_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_32_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_34_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_34_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_41_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_41_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_44_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_44_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_45_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_45_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_51_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_51_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_52_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_52_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_53_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_54_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_63_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_63_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_64_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_64_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_65_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_65_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_66_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_66_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_67_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_67_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_68_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_loop_68_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_01_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_01_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_02_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_02_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_03_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_03_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_04_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_04_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_05_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_05_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_06_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_06_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_07_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_07_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_08_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_08_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_09_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_09_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_10_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_10_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_11_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_11_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_12_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_12_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_13_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_13_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_14_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_14_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_15_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_15_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_17_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_17_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_18_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_31_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_31_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_32_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_32_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_34_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_34_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_41_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_41_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_44_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_44_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_45_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_45_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_51_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_51_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_54_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_54_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_63_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_63_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_64_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_65_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_66_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_66_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_67_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_67_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_68_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memcpy_68_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_01_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_01_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_02_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_02_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_03_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_03_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_04_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_04_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_05_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_05_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_06_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_06_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_07_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_07_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_08_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_08_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_09_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_09_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_10_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_10_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_11_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_11_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_12_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_12_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_13_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_13_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_14_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_14_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_15_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_15_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_16_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_16_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_17_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_17_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_18_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_18_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_31_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_31_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_32_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_32_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_34_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_34_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_41_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_41_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_44_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_44_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_45_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_45_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_51_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_51_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_52_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_52_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_53_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_53_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_54_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_54_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_63_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_63_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_64_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_64_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_65_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_65_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_66_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_66_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_67_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_67_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_68_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s01---CWE126_Buffer_Overread__char_declare_memmove_68_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_01_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_01_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_02_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_02_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_03_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_03_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_04_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_04_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_05_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_05_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_06_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_06_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_07_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_07_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_08_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_08_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_09_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_09_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_10_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_10_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_11_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_11_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_12_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_12_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_13_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_13_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_14_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_14_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_15_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_15_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_16_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_16_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_17_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_17_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_18_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_18_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_21_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_21_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_22_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_22_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_31_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_31_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_32_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_32_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_34_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_34_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_41_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_41_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_42_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_42_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_44_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_44_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_45_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_45_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_51_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_51_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_52_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_52_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_53_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_53_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_54_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_54_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_61_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_61_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_63_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_63_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_64_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_64_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_65_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_65_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_66_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_66_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_67_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_67_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_68_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_loop_68_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_01_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_01_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_02_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_02_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_03_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_03_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_04_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_04_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_05_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_05_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_06_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_06_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_07_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_07_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_08_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_08_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_09_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_09_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_10_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_10_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_11_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_11_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_12_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_12_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_13_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_13_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_14_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_14_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_15_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_15_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_16_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_16_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_17_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_17_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_18_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_18_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_21_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_21_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_22_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_22_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_31_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_31_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_32_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_32_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_34_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_41_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_41_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_42_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_42_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_44_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_44_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_45_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_45_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_51_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_51_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_52_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_52_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_53_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_53_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_54_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_54_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_61_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_61_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_63_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_63_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_64_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_64_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_65_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_65_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_66_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_66_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_67_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_67_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_68_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memcpy_68_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_01_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_01_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_02_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_02_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_03_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_03_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_04_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_04_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_05_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_05_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_06_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_06_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_07_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_07_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_08_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_08_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_09_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_09_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_10_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_10_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_11_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_11_good.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_12_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_12_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_13_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_13_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_14_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_14_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_15_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_15_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_16_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_16_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_17_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_17_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_18_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_18_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_21_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_21_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_22_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_22_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_31_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_31_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_32_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_32_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_34_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_34_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_41_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_41_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_42_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_42_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_44_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_44_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_45_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_45_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_51_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_51_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_52_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_52_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_53_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_53_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_54_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_54_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_61_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_61_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_63_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_63_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_64_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_65_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_65_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_66_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_66_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_67_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_67_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_68_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE126_Buffer_Overread---s02---CWE126_Buffer_Overread__malloc_char_memmove_68_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_01_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_01_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_02_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_02_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_03_bad.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_03_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_04_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_04_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_05_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_05_good.i
@@ -1475,7 +1475,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1484,7 +1483,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1502,7 +1500,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1538,14 +1535,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1601,15 +1590,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_06_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_06_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_07_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_07_good.i
@@ -1473,7 +1473,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1482,7 +1481,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1500,7 +1498,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1536,14 +1533,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1599,15 +1588,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_08_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_08_good.i
@@ -1515,7 +1515,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1524,7 +1523,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1542,7 +1540,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1578,14 +1575,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1641,15 +1630,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_09_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_09_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_10_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_10_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_11_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_11_good.i
@@ -1495,7 +1495,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1504,7 +1503,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1522,7 +1520,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1558,14 +1555,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1621,15 +1610,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_12_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_12_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_13_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_13_good.i
@@ -1472,7 +1472,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1481,7 +1480,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1499,7 +1497,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1535,14 +1532,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1598,15 +1587,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_14_bad.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_14_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_15_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_15_good.i
@@ -1575,7 +1575,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1584,7 +1583,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1602,7 +1600,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1638,14 +1635,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1701,15 +1690,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_16_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_16_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_17_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_17_good.i
@@ -1438,7 +1438,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1447,7 +1446,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1465,7 +1463,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1501,14 +1498,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1564,15 +1553,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_18_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_18_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_21_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_21_good.i
@@ -1479,7 +1479,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1488,7 +1487,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1506,7 +1504,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1542,14 +1539,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1605,15 +1594,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_22_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_22_good.i
@@ -1489,7 +1489,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1498,7 +1497,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1516,7 +1514,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1552,14 +1549,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1615,15 +1604,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_31_bad.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_31_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_32_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_32_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_34_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_34_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_41_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_41_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_42_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_42_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_44_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_44_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_45_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_45_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_51_bad.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_51_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_52_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_52_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_53_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_53_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_54_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_54_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_61_bad.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_61_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_63_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_63_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_64_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_64_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_65_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_65_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_66_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_66_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_67_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_67_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_68_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_connect_socket_68_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_01_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_01_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_02_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_02_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_03_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_03_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_04_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_04_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_05_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_05_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_06_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_06_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_07_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_07_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_08_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_08_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_09_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_09_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_10_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_10_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_11_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_11_good.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_12_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_12_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_13_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_13_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_14_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_14_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_15_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_15_good.i
@@ -1508,7 +1508,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1517,7 +1516,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1535,7 +1533,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1571,14 +1568,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1634,15 +1623,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_16_bad.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_16_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_17_bad.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_17_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_18_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_18_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_21_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_21_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_22_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_22_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_31_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_31_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_32_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_32_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_34_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_34_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_41_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_41_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_42_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_42_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_44_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_44_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_45_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_45_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_51_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_51_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_52_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_52_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_53_bad.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_53_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_54_bad.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_54_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_61_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_61_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_63_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_63_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_64_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_64_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_65_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_65_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_66_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_66_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_67_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_67_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_68_bad.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fgets_68_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_01_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_01_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_02_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_02_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_03_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_03_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_04_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_04_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_05_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_05_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_06_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_06_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_07_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_07_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_08_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_08_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_09_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_09_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_10_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_10_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_11_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_11_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_12_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_13_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_13_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_14_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_14_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_15_bad.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_15_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_16_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_16_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_17_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_17_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_18_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_18_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_21_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_21_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_22_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_22_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_31_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_31_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_32_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_32_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_34_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_34_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_41_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_41_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_42_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_42_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_44_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_44_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_45_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_45_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_51_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_51_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_52_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_52_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_53_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_53_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_54_bad.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_54_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_61_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_61_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_63_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_63_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_64_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_64_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_65_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_65_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_66_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_66_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_67_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_67_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_68_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_fscanf_68_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_01_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_01_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_02_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_02_good.i
@@ -1490,7 +1490,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1499,7 +1498,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1517,7 +1515,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1553,14 +1550,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1616,15 +1605,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_03_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_03_good.i
@@ -1490,7 +1490,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1499,7 +1498,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1517,7 +1515,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1553,14 +1550,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1616,15 +1605,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_04_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_04_good.i
@@ -1511,7 +1511,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1520,7 +1519,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1538,7 +1536,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1574,14 +1571,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1637,15 +1626,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_05_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_05_good.i
@@ -1510,7 +1510,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1519,7 +1518,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1537,7 +1535,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1573,14 +1570,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1636,15 +1625,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_06_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_06_good.i
@@ -1509,7 +1509,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1518,7 +1517,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1536,7 +1534,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1572,14 +1569,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1635,15 +1624,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_07_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_07_good.i
@@ -1508,7 +1508,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1517,7 +1516,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1535,7 +1533,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1571,14 +1568,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1634,15 +1623,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_08_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_08_good.i
@@ -1550,7 +1550,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1559,7 +1558,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1577,7 +1575,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1613,14 +1610,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1676,15 +1665,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_09_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_09_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_10_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_10_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_11_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_11_good.i
@@ -1530,7 +1530,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1539,7 +1538,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1557,7 +1555,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1593,14 +1590,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1656,15 +1645,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_12_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_12_good.i
@@ -1481,7 +1481,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1490,7 +1489,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1508,7 +1506,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1544,14 +1541,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1607,15 +1596,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_13_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_13_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_14_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_14_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_15_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_15_good.i
@@ -1610,7 +1610,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1619,7 +1618,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1637,7 +1635,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1673,14 +1670,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1736,15 +1725,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_16_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_16_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_17_bad.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_17_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_18_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_18_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_21_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_21_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_22_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_22_good.i
@@ -1524,7 +1524,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1533,7 +1532,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1551,7 +1549,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1587,14 +1584,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1650,15 +1639,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_31_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_31_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_32_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_32_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_34_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_34_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_41_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_41_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_42_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_42_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_44_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_44_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_45_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_45_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_51_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_51_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_52_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_52_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_53_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_53_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_54_bad.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_54_good.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_61_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_61_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_63_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_63_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_64_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_64_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_65_bad.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_65_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_66_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_66_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_67_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_67_good.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_68_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__CWE839_listen_socket_68_good.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_01_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_02_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_03_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_04_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_04_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_05_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_06_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_06_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_07_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_08_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_09_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_09_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_10_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_11_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_12_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_12_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_13_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_13_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_14_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_15_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_16_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_17_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_31_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_32_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_34_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_41_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_44_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_53_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_64_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_65_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_66_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_67_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_cpy_68_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_01_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_02_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_03_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_04_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_05_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_06_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_07_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_08_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_08_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_09_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_10_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_11_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_11_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_12_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_12_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_13_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_14_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_15_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_16_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_16_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_17_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_18_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_31_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_32_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_34_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_41_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_45_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_51_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_64_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_64_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_67_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_67_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_68_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_loop_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_01_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_02_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_03_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_04_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_05_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_06_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_07_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_08_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_09_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_10_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_11_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_12_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_13_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_14_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_15_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_16_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_17_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_18_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_31_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_32_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_34_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_41_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_41_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_44_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_44_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_45_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_51_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_54_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_54_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_63_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_65_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_65_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_66_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memcpy_68_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_01_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_02_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_03_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_04_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_04_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_05_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_05_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_06_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_06_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_07_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_07_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_08_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_08_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_09_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_09_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_10_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_10_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_11_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_11_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_12_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_13_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_13_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_14_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_14_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_15_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_15_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_16_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_31_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_32_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_34_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_41_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_44_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_45_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_51_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_51_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_52_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_53_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_54_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_63_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_64_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_64_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_66_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_67_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_68_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_memmove_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_01_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_01_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_02_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_02_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_03_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_03_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_04_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_05_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_05_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_06_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_07_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_07_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_08_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_09_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_10_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_10_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_11_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_12_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_12_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_13_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_14_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_14_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_15_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_15_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_16_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_16_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_17_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_17_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_18_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_31_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_31_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_32_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_32_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_34_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_34_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_41_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_44_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_45_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_45_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_52_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_52_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_53_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_53_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_54_bad.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_54_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_63_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_63_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_64_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_64_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_66_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_66_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_68_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_alloca_ncpy_68_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_02_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_03_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_04_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_05_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_06_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_07_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_08_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_09_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_10_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_11_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_12_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_13_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_14_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_15_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_16_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_17_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_31_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_32_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_34_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_41_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_44_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_45_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_52_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_53_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_63_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_63_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_64_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_65_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_66_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_67_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_cpy_68_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_01_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_02_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_02_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_03_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_03_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_04_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_04_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_05_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_06_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_06_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_07_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_08_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_09_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_09_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_10_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_11_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_12_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_12_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_13_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_13_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_14_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_15_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_16_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_31_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_32_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_34_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_41_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_44_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_45_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_51_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_53_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_54_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_64_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_64_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_66_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_66_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_67_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_loop_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_01_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_02_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_03_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_04_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_04_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_05_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_05_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_06_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_06_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_07_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_07_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_08_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_08_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_09_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_09_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_10_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_10_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_11_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_11_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_12_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_12_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_13_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_13_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_14_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_14_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_15_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_16_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_17_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_18_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_31_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_32_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_34_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_41_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_44_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_45_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_51_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_51_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_52_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_52_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_53_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_53_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_54_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_54_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_63_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_64_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_65_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_65_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_66_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memcpy_68_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_01_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_02_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_03_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_04_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_05_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_06_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_07_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_08_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_09_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_10_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_11_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_12_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_13_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_14_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_15_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_16_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_17_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_18_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_31_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_32_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_34_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_41_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_41_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_44_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_44_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_45_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_51_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_51_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_52_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_52_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_53_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_53_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_54_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_63_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_64_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_65_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_67_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_memmove_68_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_02_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_03_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_04_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_04_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_05_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_05_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_06_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_06_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_07_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_07_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_08_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_08_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_09_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_09_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_10_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_10_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_11_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_11_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_12_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_12_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_13_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_13_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_14_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_14_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_15_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_51_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_51_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_53_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_54_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_54_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_64_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_64_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_65_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_65_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_67_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_67_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s01---CWE127_Buffer_Underread__char_declare_ncpy_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_01_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_04_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_04_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_05_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_05_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_06_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_06_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_07_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_07_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_08_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_08_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_09_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_09_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_10_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_10_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_11_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_11_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_12_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_12_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_13_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_13_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_14_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_14_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_15_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_15_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_16_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_16_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_17_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_17_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_18_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_21_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_21_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_22_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_22_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_31_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_31_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_32_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_32_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_34_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_34_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_42_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_42_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_45_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_45_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_51_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_52_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_52_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_53_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_53_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_54_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_54_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_61_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_61_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_63_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_63_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_64_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_64_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_65_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_66_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_66_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_67_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_67_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_68_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_negative_68_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_01_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_02_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_03_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_04_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_05_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_06_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_07_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_08_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_09_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_10_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_11_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_12_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_12_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_13_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_14_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_15_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_15_good.i
@@ -1493,7 +1493,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1502,7 +1501,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1520,7 +1518,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1556,14 +1553,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1619,15 +1608,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_16_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_17_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_18_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_21_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_22_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_31_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_32_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_34_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_41_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_42_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_42_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_44_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_45_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_51_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_52_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_53_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_54_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_61_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_61_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_63_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_64_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_65_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_65_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_66_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_67_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_68_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__CWE839_rand_68_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_01_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_01_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_02_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_02_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_03_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_03_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_04_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_04_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_05_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_05_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_06_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_06_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_07_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_07_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_08_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_08_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_09_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_09_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_10_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_10_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_11_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_11_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_12_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_13_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_13_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_14_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_14_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_15_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_17_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_18_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_21_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_21_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_22_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_22_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_31_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_32_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_32_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_34_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_34_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_41_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_41_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_42_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_44_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_44_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_45_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_45_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_51_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_52_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_52_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_53_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_53_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_54_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_54_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_61_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_61_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_63_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_63_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_64_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_64_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_65_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_66_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_66_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_67_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_67_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_68_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_cpy_68_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_01_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_01_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_02_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_02_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_03_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_03_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_04_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_04_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_05_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_05_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_06_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_06_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_07_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_07_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_08_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_08_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_09_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_09_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_10_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_10_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_11_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_11_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_12_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_12_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_13_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_13_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_14_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_14_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_15_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_15_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_16_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_16_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_17_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_18_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_18_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_21_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_21_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_22_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_22_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_31_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_31_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_32_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_32_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_34_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_34_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_41_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_41_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_42_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_42_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_44_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_44_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_45_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_45_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_51_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_53_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_54_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_54_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_61_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_61_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_63_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_64_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_64_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_65_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_65_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_66_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_66_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_67_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_67_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_68_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_loop_68_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_01_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_01_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_02_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_02_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_03_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_03_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_04_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_05_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_06_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_07_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_08_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_09_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_10_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_11_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_12_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_12_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_13_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_14_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_15_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_16_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_16_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_17_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_18_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_21_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_21_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_22_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_22_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_31_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_31_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_32_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_32_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_34_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_34_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_41_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_41_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_42_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_42_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_44_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_44_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_45_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_45_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_51_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_51_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_52_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_53_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_54_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_61_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_61_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_63_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_63_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_64_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_65_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_66_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_66_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_67_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_67_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_68_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memcpy_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_01_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_01_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_02_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_02_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_03_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_03_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_04_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_04_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_05_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_05_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_06_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_06_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_07_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_07_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_08_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_08_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_09_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_09_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_10_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_10_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_11_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_11_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_12_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_12_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_13_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_13_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_14_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_14_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_15_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_15_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_17_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_17_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_18_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_18_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_21_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_21_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_22_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_22_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_31_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_31_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_32_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_32_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_34_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_34_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_41_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_41_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_42_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_42_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_44_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_44_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_45_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_45_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_51_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_51_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_53_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_53_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_54_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_54_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_61_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_61_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_63_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_64_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_65_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_65_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_66_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_66_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_67_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_67_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_68_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_memmove_68_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_01_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_01_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_01_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_01_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_02_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_02_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_02_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_02_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_03_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_03_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_03_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_03_good.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_04_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_04_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_04_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_04_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_05_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_05_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_05_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_05_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_06_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_06_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_06_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_06_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_07_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_07_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_07_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_07_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_08_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_08_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_08_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_08_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_09_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_09_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_09_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_09_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_10_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_10_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_10_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_10_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_11_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_11_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_11_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_11_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_12_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_12_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_12_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_12_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_13_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_13_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_13_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_13_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_14_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_14_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_14_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_14_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_15_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_15_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_15_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_15_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_16_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_16_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_16_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_16_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_17_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_17_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_17_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_17_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_18_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_18_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_18_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_18_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_21_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_21_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_21_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_21_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_22_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_22_bad.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_22_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_22_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_31_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_31_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_31_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_31_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_32_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_32_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_32_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_32_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_34_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_34_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_34_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_34_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_41_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_41_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_41_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_41_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_42_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_42_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_42_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_42_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_44_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_44_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_44_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_44_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_45_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_45_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_45_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_45_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_51_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_51_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_51_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_51_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_52_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_52_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_52_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_52_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_53_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_53_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_53_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_53_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_54_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_54_bad.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_54_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_54_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_61_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_61_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_61_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_61_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_63_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_63_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_63_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_63_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_64_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_64_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_64_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_64_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_65_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_65_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_65_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_65_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_66_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_66_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_66_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_66_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_67_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_67_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_67_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_67_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_68_bad.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_68_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_68_good.i
+++ b/c/Juliet_Test/CWE127_Buffer_Underread---s02---CWE127_Buffer_Underread__malloc_char_ncpy_68_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_01_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_01_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_02_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_02_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_03_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_03_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_04_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_04_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_05_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_05_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_06_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_06_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_07_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_07_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_08_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_08_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_09_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_09_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_10_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_10_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_11_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_11_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_12_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_12_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_13_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_13_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_14_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_14_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_15_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_15_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_16_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_17_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_17_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_18_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_18_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_21_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_21_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_22_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_22_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_31_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_31_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_32_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_32_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_34_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_34_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_41_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_41_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_42_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_42_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_44_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_44_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_45_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_45_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_51_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_51_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_52_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_53_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_53_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_54_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_54_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_61_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_61_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_63_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_64_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_65_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_65_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_66_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_66_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_67_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_67_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_68_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_calloc_68_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_01_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_02_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_03_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_04_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_05_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_06_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_07_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_08_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_09_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_10_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_11_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_12_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_12_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_13_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_14_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_15_good.i
@@ -1503,7 +1503,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1512,7 +1511,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1530,7 +1528,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1566,14 +1563,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1629,15 +1618,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_16_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_16_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_17_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_18_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_21_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_21_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_22_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_22_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_31_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_32_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_34_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_41_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_42_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_42_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_44_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_45_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_51_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_52_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_53_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_54_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_54_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_61_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_61_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_63_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_63_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_64_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_64_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_65_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_66_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_66_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_67_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_68_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_malloc_68_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_01_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_01_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_02_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_02_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_03_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_03_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_04_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_04_good.i
@@ -1438,7 +1438,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1447,7 +1446,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1465,7 +1463,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1501,14 +1498,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1564,15 +1553,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_05_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_05_good.i
@@ -1437,7 +1437,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1446,7 +1445,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1464,7 +1462,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1500,14 +1497,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1563,15 +1552,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_06_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_06_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_07_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_07_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_08_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_08_good.i
@@ -1477,7 +1477,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1486,7 +1485,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1504,7 +1502,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1540,14 +1537,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1603,15 +1592,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_09_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_09_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_10_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_10_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_11_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_11_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_12_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_12_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_13_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_13_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_14_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_14_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_15_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_15_good.i
@@ -1529,7 +1529,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1538,7 +1537,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1556,7 +1554,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1592,14 +1589,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1655,15 +1644,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_16_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_16_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_17_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_17_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_18_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_18_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_21_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_21_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_22_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_22_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_31_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_31_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_32_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_32_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_34_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_34_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_41_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_41_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_42_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_42_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_44_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_44_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_45_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_45_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_51_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_51_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_52_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_52_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_53_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_53_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_54_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_54_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_61_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_61_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_63_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_63_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_64_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_64_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_65_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_65_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_66_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_66_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_67_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_67_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_68_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__char_realloc_68_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_02_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_03_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_04_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_04_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_05_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_06_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_06_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_07_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_08_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_09_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_09_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_10_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_11_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_12_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_12_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_13_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_13_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_14_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_15_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_16_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_17_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_18_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_18_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_21_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_21_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_22_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_22_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_32_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_41_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_41_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_42_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_42_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_44_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_44_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_45_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_51_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_52_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_53_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_54_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_54_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_61_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_61_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_63_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_64_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_65_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_66_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_67_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_calloc_68_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_01_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_02_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_03_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_05_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_07_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_08_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_08_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_10_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_11_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_11_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_12_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_12_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_14_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_15_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_16_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_17_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_21_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_21_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_22_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_22_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_31_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_32_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_34_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_41_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_44_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_45_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_51_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_52_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_53_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_54_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_61_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_64_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_65_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_66_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_67_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_malloc_68_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_01_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_02_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_03_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_04_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_05_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_06_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_07_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_08_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_09_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_10_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_11_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_12_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_12_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_13_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_14_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_15_good.i
@@ -1477,7 +1477,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1486,7 +1485,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1504,7 +1502,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1540,14 +1537,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1603,15 +1592,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_16_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_16_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_17_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_18_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_21_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_21_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_22_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_22_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_31_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_32_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_34_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_41_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_42_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_42_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_44_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_45_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_52_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_54_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_54_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_61_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_61_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_63_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_64_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_64_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_66_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_66_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int64_t_realloc_68_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_02_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_03_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_04_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_04_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_05_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_06_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_06_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_07_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_08_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_08_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_09_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_09_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_10_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_11_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_11_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_12_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_12_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_13_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_13_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_14_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_15_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_15_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_16_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_17_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_17_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_18_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_18_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_21_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_21_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_22_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_22_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_31_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_32_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_41_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_41_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_42_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_42_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_44_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_44_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_45_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_51_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_52_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_53_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_54_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_61_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_61_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_63_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_64_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_65_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_65_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_66_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_66_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_67_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_67_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_calloc_68_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_01_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_02_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_03_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_05_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_07_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_08_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_08_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_10_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_11_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_11_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_12_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_12_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_14_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_15_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_16_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_17_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_18_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_21_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_21_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_22_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_22_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_31_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_32_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_34_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_41_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_42_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_44_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_45_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_51_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_52_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_53_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_53_good.i
@@ -1332,7 +1332,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1341,7 +1340,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1359,7 +1357,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1395,14 +1392,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1458,15 +1447,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_54_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_61_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_63_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_64_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_65_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_66_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_67_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_malloc_68_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_01_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_02_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_03_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_04_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_04_good.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_05_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_05_good.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_06_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_06_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_07_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_07_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_08_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_08_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_09_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_09_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_10_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_10_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_11_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_11_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_12_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_12_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_13_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_13_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_14_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_14_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_15_good.i
@@ -1477,7 +1477,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1486,7 +1485,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1504,7 +1502,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1540,14 +1537,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1603,15 +1592,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_16_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_16_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_17_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_17_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_18_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_18_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_21_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_21_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_22_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_22_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_31_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_32_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_34_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_41_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_42_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_42_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_44_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_45_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_52_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_53_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_54_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_54_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_61_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_61_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_63_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_63_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_64_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_64_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_66_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__int_realloc_68_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_01_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_01_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_02_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_02_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_03_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_03_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_04_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_04_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_05_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_05_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_06_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_06_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_07_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_07_good.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_08_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_08_good.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_09_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_09_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_10_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_10_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_11_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_11_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_12_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_12_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_13_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_13_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_14_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_14_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_15_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_15_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_16_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_17_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_17_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_18_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_char_18_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_01_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_02_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_03_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_04_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_05_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_06_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_07_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_08_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_08_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_09_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_10_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_11_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_11_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_12_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_12_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_13_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_14_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_15_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_16_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_17_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int64_t_18_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_01_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_01_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_02_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_03_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_04_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_05_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_06_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_07_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_08_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_08_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_09_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_10_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_11_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_11_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_12_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_12_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_13_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_14_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_15_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_15_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_16_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_16_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_17_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_18_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_int_18_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_01_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_02_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_03_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_04_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_05_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_05_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_06_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_07_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_07_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_08_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_08_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_09_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_10_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_10_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_11_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_11_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_12_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_12_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_13_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_14_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_14_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_15_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_18_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_struct_twoIntsStruct_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_01_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_02_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_03_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_04_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_04_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_05_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_05_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_06_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_06_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_07_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_07_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_08_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_08_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_09_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_09_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_10_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_10_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_11_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_11_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_12_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_12_good.i
@@ -1346,7 +1346,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1355,7 +1354,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1373,7 +1371,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1409,14 +1406,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1472,15 +1461,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_13_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_13_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_14_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_14_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_15_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_15_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_16_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_16_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_17_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_17_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_18_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s01---CWE401_Memory_Leak__malloc_realloc_twoIntsStruct_18_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_01_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_02_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_03_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_04_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_05_good.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_06_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_07_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_08_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_08_good.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_09_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_10_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_11_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_11_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_12_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_12_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_13_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_14_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_15_good.i
@@ -1477,7 +1477,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1486,7 +1485,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1504,7 +1502,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1540,14 +1537,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1603,15 +1592,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_16_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_17_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_18_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_21_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_21_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_22_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_22_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_31_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_32_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_34_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_41_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_42_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_44_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_45_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_53_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_53_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_54_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_61_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_63_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_64_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s02---CWE401_Memory_Leak__strdup_char_68_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_01_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_02_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_02_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_03_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_03_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_04_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_05_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_06_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_07_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_08_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_09_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_10_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_11_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_12_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_13_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_14_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_15_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_16_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_17_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_21_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_21_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_22_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_22_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_31_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_32_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_34_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_41_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_42_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_44_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_51_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_52_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_52_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_53_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_54_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_54_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_61_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_61_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_64_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_65_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_67_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_67_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_calloc_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_01_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_04_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_05_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_06_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_07_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_08_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_09_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_10_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_11_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_12_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_12_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_13_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_14_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_15_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_16_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_16_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_17_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_17_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_18_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_21_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_22_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_32_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_34_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_41_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_42_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_42_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_44_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_45_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_51_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_52_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_52_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_53_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_54_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_54_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_61_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_61_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_63_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_64_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_64_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_65_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_66_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_66_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_67_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_malloc_68_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_01_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_01_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_02_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_02_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_03_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_03_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_04_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_05_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_06_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_07_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_08_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_08_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_09_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_10_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_11_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_11_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_12_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_12_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_13_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_14_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_15_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_15_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_16_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_17_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_17_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_18_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_18_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_21_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_21_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_22_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_22_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_31_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_31_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_32_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_32_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_34_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_34_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_41_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_42_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_42_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_44_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_45_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_51_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_52_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_52_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_53_good.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_54_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_61_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_61_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_63_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_63_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_64_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_65_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_66_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_67_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_67_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__struct_twoIntsStruct_realloc_68_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_01_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_02_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_02_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_03_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_03_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_04_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_05_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_06_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_07_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_08_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_09_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_10_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_11_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_12_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_13_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_14_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_15_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_15_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_16_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_17_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_21_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_21_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_22_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_22_good.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_31_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_32_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_34_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_41_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_42_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_44_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_51_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_52_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_53_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_54_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_61_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_63_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_64_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_65_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_66_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_67_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_67_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_calloc_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_01_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_02_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_03_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_04_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_04_good.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_05_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_05_good.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_06_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_06_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_07_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_07_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_08_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_09_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_09_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_10_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_10_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_11_good.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_12_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_12_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_13_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_13_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_14_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_14_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_15_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_15_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_16_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_16_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_17_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_17_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_18_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_18_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_21_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_22_good.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_32_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_34_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_41_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_42_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_42_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_44_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_45_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_51_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_51_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_52_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_53_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_54_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_61_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_61_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_63_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_63_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_64_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_64_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_65_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_65_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_66_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_66_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_67_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_malloc_68_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_01_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_01_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_01_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_02_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_02_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_02_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_03_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_03_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_03_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_04_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_04_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_04_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_05_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_05_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_05_good.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_06_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_06_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_06_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_07_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_07_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_07_good.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_08_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_08_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_08_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_09_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_09_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_09_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_10_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_10_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_10_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_11_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_11_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_11_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_12_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_12_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_12_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_13_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_13_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_13_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_14_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_14_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_14_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_15_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_15_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_15_good.i
@@ -1485,7 +1485,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1494,7 +1493,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1512,7 +1510,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1548,14 +1545,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1611,15 +1600,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_16_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_16_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_16_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_17_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_17_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_17_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_18_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_18_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_18_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_21_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_21_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_21_good.i
@@ -1389,7 +1389,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1398,7 +1397,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1416,7 +1414,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1452,14 +1449,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1515,15 +1504,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_22_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_22_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_22_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_31_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_31_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_31_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_32_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_32_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_32_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_34_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_34_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_34_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_41_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_41_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_41_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_42_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_42_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_42_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_44_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_44_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_44_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_45_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_51_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_51_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_51_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_52_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_52_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_52_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_53_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_53_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_53_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_54_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_54_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_61_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_61_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_61_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_63_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_63_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_63_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_64_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_64_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_64_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_65_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_65_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_65_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_66_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_66_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_67_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_67_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_67_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_good.i
+++ b/c/Juliet_Test/CWE401_Memory_Leak---s03---CWE401_Memory_Leak__twoIntsStruct_realloc_68_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_01_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_01_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_02_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_02_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_03_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_03_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_04_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_04_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_04_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_05_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_05_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_06_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_06_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_06_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_07_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_07_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_08_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_08_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_08_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_09_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_09_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_09_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_10_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_10_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_11_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_11_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_11_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_12_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_12_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_12_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_13_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_13_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_13_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_14_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_14_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_15_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_15_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_15_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_16_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_16_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_17_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_17_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_18_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_18_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_21_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_21_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_21_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_21_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_22_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_22_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_22_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_22_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_31_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_31_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_32_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_32_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_34_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_34_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_41_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_41_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_42_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_42_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_44_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_44_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_45_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_45_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_51_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_51_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_52_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_52_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_52_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_53_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_53_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_53_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_54_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_54_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_54_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_61_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_61_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_63_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_63_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_64_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_64_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_65_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_65_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_66_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_66_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_66_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_67_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_67_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_68_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_68_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_char_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_01_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_01_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_02_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_02_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_03_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_03_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_04_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_04_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_04_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_05_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_05_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_06_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_06_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_06_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_07_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_07_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_08_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_08_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_08_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_09_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_09_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_09_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_10_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_10_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_11_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_11_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_11_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_12_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_12_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_12_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_13_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_13_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_13_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_14_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_14_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_15_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_15_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_15_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_16_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_16_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_17_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_17_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_18_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_18_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_21_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_21_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_21_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_21_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_22_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_22_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_22_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_22_good.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_31_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_31_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_32_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_32_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_34_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_34_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_41_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_41_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_42_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_42_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_44_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_44_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_45_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_45_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_51_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_51_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_52_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_52_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_52_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_53_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_53_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_53_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_54_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_54_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_54_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_61_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_61_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_63_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_63_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_63_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_64_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_64_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_65_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_65_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_66_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_66_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_66_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_67_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_67_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_68_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_68_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int64_t_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_01_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_01_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_02_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_02_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_03_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_03_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_04_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_04_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_04_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_05_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_05_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_06_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_06_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_06_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_07_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_07_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_08_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_08_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_08_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_09_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_09_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_09_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_10_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_10_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_11_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_11_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_11_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_12_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_12_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_12_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_13_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_13_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_13_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_14_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_14_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_15_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_15_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_15_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_16_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_16_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_17_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_17_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_18_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_18_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_21_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_21_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_21_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_21_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_22_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_22_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_22_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_22_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_31_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_31_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_32_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_32_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_34_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_34_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_41_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_41_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_42_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_42_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_44_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_44_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_45_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_45_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_51_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_51_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_52_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_52_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_53_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_53_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_53_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_53_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_54_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_54_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_54_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_61_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_61_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_63_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_63_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_64_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_64_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_65_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_65_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_65_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_66_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_66_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_67_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_67_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_67_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_68_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_68_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_int_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_01_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_01_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_02_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_02_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_03_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_03_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_04_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_04_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_04_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_05_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_05_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_06_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_06_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_06_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_07_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_07_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_08_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_08_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_08_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_09_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_09_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_09_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_10_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_10_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_11_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_11_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_11_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_12_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_12_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_12_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_13_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_13_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_13_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_14_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_14_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_15_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_15_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_15_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_16_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_16_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_17_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_17_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_18_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_18_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_21_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_21_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_21_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_21_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_22_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_22_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_22_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_22_good.i
@@ -1370,7 +1370,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1379,7 +1378,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1397,7 +1395,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1433,14 +1430,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1496,15 +1485,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_31_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_31_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_32_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_32_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_34_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_34_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_41_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_41_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_42_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_42_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_44_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_44_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_45_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_45_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_51_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_51_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_52_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_52_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_53_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_53_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_53_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_54_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_54_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_54_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_61_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_61_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_61_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_61_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_63_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_63_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_64_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_64_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_65_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_65_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_65_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_66_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_66_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_66_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_67_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_67_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_67_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_68_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_68_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_long_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_01_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_01_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_01_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_02_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_02_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_02_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_03_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_03_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_03_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_04_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_04_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_04_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_04_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_05_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_05_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_05_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_05_good.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_06_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_06_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_06_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_06_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_07_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_07_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_07_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_07_good.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_08_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_08_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_08_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_08_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_09_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_09_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_09_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_09_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_10_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_10_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_10_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_10_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_11_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_11_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_11_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_11_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_12_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_12_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_12_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_13_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_13_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_13_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_13_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_14_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_14_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_14_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_14_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_15_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_15_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_15_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_15_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_16_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_16_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_16_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_16_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_17_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_17_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_17_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_17_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_18_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_18_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_18_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_18_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_21_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_21_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_21_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_21_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_22_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_22_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_22_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_22_good.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_31_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_31_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_31_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_32_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_32_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_32_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_34_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_34_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_34_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_41_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_41_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_42_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_42_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_44_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_44_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_44_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_45_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_45_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_45_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_51_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_51_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_51_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_52_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_52_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_52_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_53_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_53_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_53_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_53_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_54_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_54_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_54_good.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_61_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_61_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_63_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_63_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_63_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_64_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_64_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_64_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_65_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_65_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_65_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_66_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_66_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_66_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_67_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_67_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_67_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_68_bad.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_68_good.i
+++ b/c/Juliet_Test/CWE415_Double_Free---s01---CWE415_Double_Free__malloc_free_struct_68_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_01_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_01_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_02_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_02_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_03_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_03_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_04_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_04_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_05_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_05_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_06_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_06_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_07_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_07_good.i
@@ -1392,7 +1392,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1401,7 +1400,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1419,7 +1417,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1455,14 +1452,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1518,15 +1507,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_08_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_08_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_09_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_09_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_10_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_10_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_11_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_11_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_12_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_12_good.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_13_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_13_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_14_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_14_good.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_15_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_15_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_16_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_16_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_17_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_17_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_18_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_63_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_63_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_63_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_63_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_64_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_64_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_64_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_char_64_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_01_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_01_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_02_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_02_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_03_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_03_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_04_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_05_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_06_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_07_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_08_good.i
@@ -1499,7 +1499,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1508,7 +1507,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1526,7 +1524,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1562,14 +1559,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1625,15 +1614,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_09_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_10_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_11_good.i
@@ -1479,7 +1479,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1488,7 +1487,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1506,7 +1504,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1542,14 +1539,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1605,15 +1594,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_12_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_12_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_13_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_14_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_15_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_15_good.i
@@ -1551,7 +1551,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1560,7 +1559,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1578,7 +1576,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1614,14 +1611,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1677,15 +1666,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_16_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_16_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_17_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_17_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_18_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_18_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_63_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_63_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_63_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_64_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_64_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_64_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int64_t_64_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_01_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_01_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_02_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_02_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_03_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_03_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_04_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_05_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_06_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_07_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_08_good.i
@@ -1499,7 +1499,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1508,7 +1507,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1526,7 +1524,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1562,14 +1559,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1625,15 +1614,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_09_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_10_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_11_good.i
@@ -1479,7 +1479,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1488,7 +1487,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1506,7 +1504,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1542,14 +1539,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1605,15 +1594,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_12_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_12_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_13_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_14_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_15_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_15_good.i
@@ -1551,7 +1551,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1560,7 +1559,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1578,7 +1576,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1614,14 +1611,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1677,15 +1666,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_16_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_16_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_17_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_17_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_18_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_18_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_63_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_63_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_63_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_64_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_64_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_64_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_int_64_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_01_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_01_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_02_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_02_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_03_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_03_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_04_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_04_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_05_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_05_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_06_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_06_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_07_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_07_good.i
@@ -1457,7 +1457,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1466,7 +1465,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1484,7 +1482,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1520,14 +1517,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1583,15 +1572,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_08_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_08_good.i
@@ -1499,7 +1499,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1508,7 +1507,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1526,7 +1524,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1562,14 +1559,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1625,15 +1614,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_09_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_09_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_10_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_10_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_11_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_11_good.i
@@ -1479,7 +1479,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1488,7 +1487,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1506,7 +1504,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1542,14 +1539,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1605,15 +1594,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_12_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_12_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_13_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_13_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_14_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_14_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_15_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_15_good.i
@@ -1551,7 +1551,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1560,7 +1559,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1578,7 +1576,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1614,14 +1611,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1677,15 +1666,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_16_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_16_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_17_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_17_good.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_18_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_18_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_63_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_63_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_63_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_63_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_64_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_64_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_64_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_long_64_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_01_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_01_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_02_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_02_good.i
@@ -1439,7 +1439,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1448,7 +1447,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1466,7 +1464,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1502,14 +1499,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1565,15 +1554,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_03_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_03_good.i
@@ -1439,7 +1439,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1448,7 +1447,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1466,7 +1464,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1502,14 +1499,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1565,15 +1554,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_04_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_04_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_05_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_05_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_06_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_06_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_07_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_07_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_08_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_08_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_09_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_09_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_10_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_10_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_11_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_11_good.i
@@ -1487,7 +1487,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1496,7 +1495,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1514,7 +1512,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1550,14 +1547,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1613,15 +1602,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_12_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_12_good.i
@@ -1440,7 +1440,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1449,7 +1448,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1467,7 +1465,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1503,14 +1500,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1566,15 +1555,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_13_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_13_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_14_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_14_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_15_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_15_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_16_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_16_good.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_17_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_17_good.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_18_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_18_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_63_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_63_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_63_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_63_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_64_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_64_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_64_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__malloc_free_struct_64_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_01_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_01_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_01_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_01_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_02_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_02_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_02_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_02_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_03_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_03_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_03_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_03_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_04_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_04_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_04_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_04_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_05_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_05_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_05_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_05_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_06_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_06_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_06_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_06_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_07_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_07_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_07_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_07_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_08_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_08_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_08_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_08_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_09_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_09_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_09_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_09_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_10_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_10_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_10_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_10_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_11_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_11_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_11_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_11_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_12_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_12_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_12_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_12_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_13_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_13_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_13_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_13_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_14_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_14_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_14_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_14_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_15_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_15_bad.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_15_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_15_good.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_16_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_16_bad.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_16_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_16_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_17_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_17_bad.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_17_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_17_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_18_bad.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_18_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_18_good.i
+++ b/c/Juliet_Test/CWE416_Use_After_Free---CWE416_Use_After_Free__return_freed_ptr_18_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_01_bad.i
@@ -1229,7 +1229,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1238,7 +1237,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1256,7 +1254,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1292,14 +1289,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1355,15 +1344,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_01_good.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_02_bad.i
@@ -1229,7 +1229,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1238,7 +1237,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1256,7 +1254,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1292,14 +1289,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1355,15 +1344,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_02_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_03_bad.i
@@ -1229,7 +1229,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1238,7 +1237,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1256,7 +1254,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1292,14 +1289,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1355,15 +1344,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_03_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_04_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_04_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_05_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_05_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_06_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_06_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_07_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_07_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_08_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_09_bad.i
@@ -1233,7 +1233,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1242,7 +1241,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1260,7 +1258,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1296,14 +1293,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1359,15 +1348,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_09_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_10_bad.i
@@ -1233,7 +1233,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1242,7 +1241,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1260,7 +1258,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1296,14 +1293,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1359,15 +1348,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_10_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_11_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_12_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_12_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_13_bad.i
@@ -1233,7 +1233,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1242,7 +1241,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1260,7 +1258,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1296,14 +1293,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1359,15 +1348,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_13_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_14_bad.i
@@ -1233,7 +1233,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1242,7 +1241,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1260,7 +1258,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1296,14 +1293,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1359,15 +1348,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_14_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_15_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_15_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_16_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_16_good.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_17_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_17_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_18_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__binary_if_18_good.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_01_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_02_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_03_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_04_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_04_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_05_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_05_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_06_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_06_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_07_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_07_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_08_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_09_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_09_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_10_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_10_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_11_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_12_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_13_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_13_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_14_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_14_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_15_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_16_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_17_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_18_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_18_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_21_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_21_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_21_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_21_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_22_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_22_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_22_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_22_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_31_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_31_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_31_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_32_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_32_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_32_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_32_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_34_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_34_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_34_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_34_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_41_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_41_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_41_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_44_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_44_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_44_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_44_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_45_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_45_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_45_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_45_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_51_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_51_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_51_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_51_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_52_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_52_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_52_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_52_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_53_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_53_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_53_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_54_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_54_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_54_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_63_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_63_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_63_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_63_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_64_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_64_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_64_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_64_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_65_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_65_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_65_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_65_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_66_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_66_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_66_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_66_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_67_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_67_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_67_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_67_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_68_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_68_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_68_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__char_68_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_01_good.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_02_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_03_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_04_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_04_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_05_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_05_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_06_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_06_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_07_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_07_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_08_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_08_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_09_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_09_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_10_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_10_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_11_bad.i
@@ -1235,7 +1235,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1244,7 +1243,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1262,7 +1260,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1298,14 +1295,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1361,15 +1350,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_11_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_12_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_12_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_13_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_13_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_14_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_14_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_15_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_15_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_16_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_16_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_17_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_17_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_18_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__deref_after_check_18_good.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_01_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_02_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_03_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_04_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_05_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_05_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_06_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_07_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_07_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_09_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_10_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_10_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_12_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_13_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_14_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_14_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_15_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_17_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_18_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_21_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_21_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_21_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_21_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_22_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_22_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_22_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_22_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_31_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_31_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_31_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_31_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_32_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_32_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_32_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_32_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_34_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_34_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_34_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_41_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_41_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_41_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_41_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_44_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_44_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_44_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_45_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_45_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_45_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_51_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_51_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_51_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_51_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_52_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_52_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_52_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_52_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_53_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_53_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_53_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_53_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_54_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_54_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_54_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_54_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_63_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_63_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_63_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_63_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_64_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_64_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_64_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_65_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_65_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_65_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_66_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_66_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_66_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_66_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_67_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_67_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_67_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_67_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_68_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_68_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_68_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int64_t_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_01_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_02_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_03_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_04_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_05_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_05_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_06_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_07_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_07_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_09_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_10_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_10_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_12_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_13_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_14_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_14_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_15_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_17_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_18_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_21_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_21_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_21_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_21_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_22_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_22_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_22_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_22_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_31_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_31_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_31_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_31_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_32_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_32_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_32_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_32_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_34_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_34_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_34_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_41_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_41_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_41_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_41_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_44_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_44_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_44_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_45_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_45_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_45_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_51_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_51_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_51_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_51_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_52_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_52_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_52_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_52_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_53_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_53_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_53_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_53_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_54_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_54_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_54_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_54_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_63_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_63_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_63_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_64_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_64_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_64_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_64_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_65_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_65_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_65_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_66_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_66_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_66_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_66_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_67_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_67_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_67_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_67_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_68_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_68_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_68_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__int_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_01_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_02_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_03_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_04_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_04_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_05_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_05_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_06_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_06_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_07_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_07_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_09_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_09_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_10_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_10_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_12_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_12_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_13_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_13_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_14_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_14_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_15_good.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_16_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_17_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_18_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_18_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_21_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_21_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_21_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_21_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_22_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_22_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_22_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_22_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_31_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_31_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_31_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_31_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_32_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_32_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_32_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_32_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_34_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_34_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_34_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_41_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_41_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_41_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_41_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_44_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_44_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_44_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_44_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_45_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_45_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_45_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_45_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_51_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_51_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_51_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_51_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_52_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_52_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_52_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_52_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_53_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_53_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_53_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_53_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_54_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_54_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_54_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_54_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_63_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_63_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_63_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_64_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_64_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_64_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_64_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_65_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_65_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_65_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_66_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_66_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_66_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_66_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_67_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_67_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_67_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_67_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_68_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_68_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_68_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__long_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_01_good.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_02_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_03_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_04_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_04_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_05_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_05_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_06_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_06_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_07_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_07_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_08_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_08_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_09_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_09_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_10_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_10_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_11_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_11_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_12_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_13_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_13_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_14_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_14_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_15_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_15_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_16_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_16_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_17_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_17_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_18_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__null_check_after_deref_18_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_01_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_01_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_01_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_01_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_02_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_02_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_02_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_02_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_03_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_03_bad.i
@@ -1228,7 +1228,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1237,7 +1236,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1255,7 +1253,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1291,14 +1288,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1354,15 +1343,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_03_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_03_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_04_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_04_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_04_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_04_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_05_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_05_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_05_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_05_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_06_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_06_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_06_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_06_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_07_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_07_bad.i
@@ -1232,7 +1232,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1241,7 +1240,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1259,7 +1257,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1295,14 +1292,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1358,15 +1347,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_07_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_07_good.i
@@ -1317,7 +1317,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1326,7 +1325,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1344,7 +1342,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1380,14 +1377,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1443,15 +1432,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_08_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_08_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_08_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_08_good.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_09_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_09_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_09_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_09_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_10_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_10_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_10_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_10_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_11_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_11_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_11_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_11_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_12_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_12_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_12_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_12_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_13_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_13_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_13_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_13_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_14_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_14_bad.i
@@ -1230,7 +1230,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1239,7 +1238,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1257,7 +1255,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1293,14 +1290,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1356,15 +1345,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_14_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_14_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_15_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_15_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_15_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_15_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_16_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_16_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_16_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_17_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_17_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_17_good.i
@@ -1326,7 +1326,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1335,7 +1334,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1353,7 +1351,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1389,14 +1386,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1452,15 +1441,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_18_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_18_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_18_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_18_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_21_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_21_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_21_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_21_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_22_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_22_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_22_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_22_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_31_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_31_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_31_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_31_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_32_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_32_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_32_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_34_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_34_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_34_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_34_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_41_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_41_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_41_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_41_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_44_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_44_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_44_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_44_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_45_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_45_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_45_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_51_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_51_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_51_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_51_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_52_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_52_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_52_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_52_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_53_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_53_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_53_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_53_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_54_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_54_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_54_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_54_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_63_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_63_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_63_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_63_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_64_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_64_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_64_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_64_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_65_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_65_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_65_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_65_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_66_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_66_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_66_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_67_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_67_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_67_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_68_bad.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_68_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_68_good.i
+++ b/c/Juliet_Test/CWE476_NULL_Pointer_Dereference---CWE476_NULL_Pointer_Dereference__struct_68_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_01_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_02_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_02_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_03_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_03_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_04_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_04_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_05_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_06_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_06_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_07_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_08_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_09_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_09_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_10_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_11_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_12_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_12_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_13_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_13_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_14_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_15_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_15_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_16_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_17_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_18_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_31_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_32_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_34_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_41_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_44_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_45_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_51_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_52_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_52_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_53_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_53_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_54_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_63_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_63_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_64_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_64_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_65_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_65_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_66_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_67_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_68_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_alloca_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_01_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_02_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_02_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_03_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_03_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_04_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_04_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_05_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_06_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_06_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_07_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_08_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_09_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_09_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_10_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_11_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_12_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_13_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_13_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_14_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_15_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_15_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_16_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_17_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_18_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_31_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_32_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_34_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_41_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_44_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_45_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_51_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_52_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_52_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_53_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_54_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_54_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_63_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_64_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_65_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_65_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_66_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_66_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_67_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_68_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_declare_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_01_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_01_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_02_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_02_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_03_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_03_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_04_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_04_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_05_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_05_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_06_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_06_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_07_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_07_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_08_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_08_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_09_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_09_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_10_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_10_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_11_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_11_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_12_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_12_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_13_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_13_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_14_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_14_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_15_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_15_good.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_16_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_16_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_17_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_17_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_18_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_18_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_31_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_31_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_32_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_32_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_34_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_34_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_41_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_41_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_44_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_44_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_45_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_45_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_51_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_51_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_52_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_52_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_53_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_53_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_54_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_54_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_63_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_63_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_64_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_64_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_65_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_65_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_66_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_66_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_67_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_67_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_68_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_char_static_68_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_12_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_alloca_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_52_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_53_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_54_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_declare_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_52_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_54_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_54_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_64_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int64_t_static_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_12_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_53_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_54_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_63_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_66_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_66_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_alloca_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_53_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_54_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_54_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_declare_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_53_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_54_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_54_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_int_static_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_01_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_02_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_03_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_04_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_05_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_06_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_07_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_08_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_09_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_10_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_11_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_12_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_13_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_14_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_15_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_16_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_17_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_18_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_31_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_32_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_34_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_41_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_44_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_45_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_53_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_53_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_54_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_63_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_63_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_64_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_66_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_67_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_68_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_alloca_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_51_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_51_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_52_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_52_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_53_bad.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_53_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_65_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_65_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_67_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_67_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s04---CWE590_Free_Memory_Not_on_Heap__free_long_declare_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_01_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_01_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_02_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_02_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_03_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_03_good.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_04_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_04_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_05_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_05_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_06_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_06_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_07_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_07_good.i
@@ -1356,7 +1356,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1365,7 +1364,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1383,7 +1381,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1419,14 +1416,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1482,15 +1471,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_08_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_08_good.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_09_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_09_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_10_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_10_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_11_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_11_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_12_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_12_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_13_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_13_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_14_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_14_good.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_15_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_15_good.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_16_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_16_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_17_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_17_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_18_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_18_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_31_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_31_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_32_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_32_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_34_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_34_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_41_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_41_good.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_44_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_44_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_45_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_45_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_51_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_51_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_52_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_52_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_53_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_53_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_54_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_54_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_63_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_63_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_64_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_64_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_65_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_65_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_66_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_66_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_67_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_67_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_68_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_long_static_68_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_01_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_01_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_02_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_02_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_03_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_03_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_04_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_04_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_05_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_06_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_06_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_07_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_08_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_08_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_09_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_09_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_10_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_11_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_11_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_12_bad.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_12_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_13_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_13_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_14_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_15_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_15_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_16_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_16_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_17_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_17_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_18_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_18_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_31_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_32_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_32_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_34_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_41_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_44_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_45_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_45_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_51_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_52_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_53_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_54_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_54_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_63_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_63_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_64_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_66_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_67_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_67_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_68_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_alloca_68_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_01_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_02_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_03_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_04_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_06_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_08_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_09_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_11_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_12_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_12_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_13_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_15_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_16_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_17_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_18_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_32_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_41_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_44_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_45_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_51_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_52_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_52_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_53_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_53_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_54_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_63_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_63_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_64_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_64_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_65_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_65_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_66_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_66_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_67_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_declare_68_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_01_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_01_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_01_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_01_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_02_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_02_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_02_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_02_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_03_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_03_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_03_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_03_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_04_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_04_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_04_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_04_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_05_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_05_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_05_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_05_good.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_06_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_06_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_06_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_06_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_07_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_07_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_07_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_07_good.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_08_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_08_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_08_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_08_good.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_09_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_09_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_09_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_09_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_10_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_10_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_10_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_10_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_11_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_11_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_11_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_11_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_12_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_12_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_12_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_12_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_13_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_13_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_13_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_13_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_14_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_14_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_14_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_14_good.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_15_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_15_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_15_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_15_good.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_16_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_16_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_16_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_16_good.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_17_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_17_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_17_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_17_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_18_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_18_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_18_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_18_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_31_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_31_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_31_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_31_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_32_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_32_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_32_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_32_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_34_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_34_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_34_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_34_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_41_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_41_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_41_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_41_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_44_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_44_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_44_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_44_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_45_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_45_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_45_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_45_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_51_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_51_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_51_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_51_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_52_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_52_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_52_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_52_good.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_53_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_53_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_53_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_53_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_54_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_54_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_54_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_54_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_63_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_63_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_63_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_63_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_64_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_64_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_64_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_64_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_65_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_65_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_65_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_65_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_66_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_66_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_66_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_66_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_67_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_67_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_67_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_67_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_68_bad.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_68_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_68_good.i
+++ b/c/Juliet_Test/CWE590_Free_Memory_Not_on_Heap---s05---CWE590_Free_Memory_Not_on_Heap__free_struct_static_68_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_01_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_01_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_02_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_02_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_03_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_03_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_04_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_04_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_05_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_05_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_06_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_06_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_07_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_07_good.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_08_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_08_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_09_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_09_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_10_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_10_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_11_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_11_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_12_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_12_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_13_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_13_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_14_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_14_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_15_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_15_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_16_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_16_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_17_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_17_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_18_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_18_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_21_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_21_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_22_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_22_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_31_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_31_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_32_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_32_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_34_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_34_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_41_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_41_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_42_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_42_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_44_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_44_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_45_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_45_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_51_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_51_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_54_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_54_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_61_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_61_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_63_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_64_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_65_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_65_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_66_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_67_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_68_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_calloc_68_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_04_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_05_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_06_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_07_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_08_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_09_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_10_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_11_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_12_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_12_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_13_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_14_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_21_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_22_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_42_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_54_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_61_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_64_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_65_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_65_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_67_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_67_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_malloc_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_01_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_01_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_02_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_02_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_03_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_03_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_04_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_04_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_05_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_05_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_06_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_06_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_07_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_07_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_08_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_08_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_09_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_09_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_10_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_10_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_11_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_11_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_12_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_12_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_13_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_13_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_14_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_14_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_15_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_15_good.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_16_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_16_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_17_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_17_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_18_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_18_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_21_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_21_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_22_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_22_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_31_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_31_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_32_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_32_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_34_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_34_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_41_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_41_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_42_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_42_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_44_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_44_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_45_bad.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_45_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_51_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_51_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_52_bad.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_52_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_53_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_53_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_54_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_54_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_61_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_61_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_63_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_63_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_64_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_64_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_65_bad.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_65_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_66_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_66_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_67_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_67_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_68_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__char_realloc_68_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_01_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_01_good.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_02_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_02_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_03_bad.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_03_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_04_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_04_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_05_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_05_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_06_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_06_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_07_bad.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_07_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_08_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_08_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_09_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_09_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_10_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_10_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_11_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_11_good.i
@@ -1325,7 +1325,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1334,7 +1333,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1352,7 +1350,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1388,14 +1385,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1451,15 +1440,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_12_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_12_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_13_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_13_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_14_bad.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_14_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_15_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_15_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_16_bad.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_16_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_17_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_17_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_18_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_18_good.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_21_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_21_good.i
@@ -1345,7 +1345,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1354,7 +1353,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1372,7 +1370,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1408,14 +1405,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1471,15 +1460,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_22_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_22_good.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_31_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_31_good.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_32_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_32_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_34_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_34_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_41_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_41_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_42_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_42_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_44_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_44_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_45_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_45_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_51_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_51_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_52_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_52_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_53_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_53_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_54_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_54_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_61_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_61_good.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_63_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_63_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_64_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_64_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_65_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_65_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_66_bad.i
@@ -1298,7 +1298,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1307,7 +1306,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1325,7 +1323,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1361,14 +1358,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1424,15 +1413,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_66_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_67_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_67_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_68_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__fopen_68_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_01_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_01_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_02_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_02_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_03_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_03_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_04_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_04_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_05_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_05_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_06_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_06_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_07_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_07_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_08_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_08_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_09_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_09_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_10_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_10_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_11_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_11_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_12_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_13_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_13_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_14_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_14_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_15_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_15_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_16_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_16_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_17_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_17_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_18_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_18_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_21_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_21_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_22_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_22_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_31_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_31_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_32_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_32_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_34_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_34_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_41_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_41_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_42_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_42_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_44_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_44_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_45_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_45_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_52_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_52_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_53_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_53_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_54_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_61_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_61_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_63_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_63_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_64_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_64_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_65_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_65_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_66_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_66_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_67_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_67_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_68_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_calloc_68_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_01_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_01_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_02_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_02_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_03_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_03_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_04_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_04_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_05_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_05_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_06_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_06_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_07_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_07_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_08_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_08_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_09_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_09_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_10_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_10_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_11_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_11_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_12_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_13_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_13_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_14_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_14_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_15_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_15_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_16_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_16_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_17_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_17_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_18_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_18_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_21_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_21_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_22_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_22_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_31_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_31_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_32_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_32_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_34_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_34_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_41_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_42_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_42_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_44_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_45_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_45_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_53_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_53_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_54_bad.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_54_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_61_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_61_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_63_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_63_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_64_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_64_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_65_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_66_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_66_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_67_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_67_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_68_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_malloc_68_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_04_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_05_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_06_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_07_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_08_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_09_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_10_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_11_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_13_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_14_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_21_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_22_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_42_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_53_bad.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_53_good.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_61_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_61_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int64_t_realloc_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_01_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_01_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_02_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_02_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_03_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_03_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_04_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_04_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_05_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_05_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_06_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_06_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_07_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_07_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_08_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_08_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_09_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_09_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_10_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_10_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_11_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_11_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_12_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_13_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_13_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_14_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_14_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_15_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_15_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_16_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_16_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_17_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_17_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_18_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_18_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_21_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_21_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_22_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_22_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_31_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_31_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_32_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_32_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_34_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_34_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_41_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_41_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_42_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_42_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_44_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_44_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_45_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_45_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_53_bad.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_53_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_54_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_54_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_61_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_61_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_63_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_63_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_64_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_64_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_65_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_65_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_66_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_66_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_67_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_67_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_68_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_calloc_68_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_01_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_01_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_02_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_02_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_03_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_03_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_04_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_04_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_05_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_05_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_06_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_06_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_07_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_07_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_08_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_08_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_09_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_09_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_10_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_10_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_11_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_11_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_12_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_13_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_13_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_14_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_14_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_15_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_15_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_16_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_16_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_17_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_17_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_18_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_18_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_21_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_21_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_22_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_22_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_31_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_31_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_32_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_32_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_34_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_34_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_41_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_42_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_42_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_44_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_45_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_45_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_51_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_51_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_53_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_53_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_54_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_54_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_61_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_61_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_63_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_63_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_64_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_64_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_65_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_65_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_66_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_66_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_67_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_67_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_68_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_malloc_68_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_04_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_05_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_06_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_07_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_08_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_09_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_10_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_11_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_13_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_14_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_21_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_22_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_42_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_52_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_52_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_53_bad.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_53_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_54_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_54_good.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_61_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_61_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_63_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_63_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_64_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_64_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_66_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_66_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__int_realloc_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_01_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_01_good.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_02_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_02_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_03_bad.i
@@ -1237,7 +1237,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1246,7 +1245,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1264,7 +1262,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1300,14 +1297,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1363,15 +1352,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_03_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_04_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_04_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_05_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_05_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_06_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_06_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_07_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_07_good.i
@@ -1284,7 +1284,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1293,7 +1292,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1311,7 +1309,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1347,14 +1344,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1410,15 +1399,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_08_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_08_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_09_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_09_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_10_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_10_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_11_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_11_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_12_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_12_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_13_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_13_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_14_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_14_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_15_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_15_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_16_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_16_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_17_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_17_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_18_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_18_good.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_21_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_21_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_22_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_22_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_31_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_31_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_32_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_32_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_34_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_34_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_41_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_41_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_42_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_42_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_44_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_44_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_45_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_45_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_52_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_52_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_53_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_53_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_54_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_54_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_61_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_61_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_63_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_63_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_64_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_64_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_65_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_66_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_66_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_67_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_67_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_68_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_calloc_68_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_01_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_01_good.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_02_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_02_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_03_bad.i
@@ -1234,7 +1234,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1243,7 +1242,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1261,7 +1259,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1297,14 +1294,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1360,15 +1349,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_03_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_04_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_04_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_05_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_05_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_06_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_06_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_07_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_07_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_08_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_08_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_09_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_09_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_10_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_10_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_11_bad.i
@@ -1241,7 +1241,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1250,7 +1249,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1268,7 +1266,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1304,14 +1301,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1367,15 +1356,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_11_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_12_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_12_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_13_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_13_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_14_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_14_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_15_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_15_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_16_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_16_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_17_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_17_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_18_bad.i
@@ -1238,7 +1238,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1247,7 +1246,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1265,7 +1263,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1301,14 +1298,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1364,15 +1353,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_18_good.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_21_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_21_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_22_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_22_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_31_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_31_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_32_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_32_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_34_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_34_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_41_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_41_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_42_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_42_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_44_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_44_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_45_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_45_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_51_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_51_good.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_52_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_52_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_53_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_53_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_54_bad.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_54_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_61_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_61_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_63_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_63_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_64_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_64_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_65_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_65_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_66_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_66_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_67_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_67_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_68_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s01---CWE690_NULL_Deref_From_Return__long_malloc_68_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_01_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_01_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_02_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_02_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_03_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_03_good.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_04_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_04_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_05_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_05_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_06_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_06_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_07_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_07_good.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_08_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_08_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_09_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_09_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_10_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_10_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_11_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_11_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_12_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_12_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_13_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_13_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_14_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_14_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_15_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_15_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_16_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_16_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_17_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_17_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_18_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_18_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_21_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_21_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_22_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_22_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_31_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_31_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_32_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_32_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_34_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_34_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_41_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_41_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_42_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_42_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_44_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_44_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_45_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_45_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_51_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_51_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_52_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_52_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_53_bad.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_53_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_54_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_54_good.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_61_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_61_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_63_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_63_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_64_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_64_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_65_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_65_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_66_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_66_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_67_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_67_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_68_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__long_realloc_68_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_01_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_01_good.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_02_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_02_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_03_bad.i
@@ -1239,7 +1239,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1248,7 +1247,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1266,7 +1264,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1302,14 +1299,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1365,15 +1354,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_03_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_04_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_04_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_05_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_05_good.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_06_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_06_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_07_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_07_good.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_08_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_08_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_09_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_09_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_10_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_10_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_11_bad.i
@@ -1246,7 +1246,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1255,7 +1254,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1273,7 +1271,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1309,14 +1306,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1372,15 +1361,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_11_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_12_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_12_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_13_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_13_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_14_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_14_good.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_15_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_15_good.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_16_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_16_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_17_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_17_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_18_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_18_good.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_21_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_21_good.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_22_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_22_good.i
@@ -1319,7 +1319,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1328,7 +1327,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1346,7 +1344,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1382,14 +1379,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1445,15 +1434,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_31_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_31_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_32_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_32_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_34_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_34_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_41_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_41_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_42_bad.i
@@ -1248,7 +1248,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1257,7 +1256,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1275,7 +1273,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1311,14 +1308,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1374,15 +1363,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_42_good.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_44_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_44_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_45_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_45_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_51_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_51_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_52_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_52_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_53_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_53_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_54_bad.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_54_good.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_61_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_61_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_63_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_63_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_64_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_64_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_65_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_65_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_66_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_66_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_67_bad.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_67_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_68_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_calloc_68_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_01_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_01_good.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_02_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_02_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_03_bad.i
@@ -1236,7 +1236,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1245,7 +1244,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1263,7 +1261,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1299,14 +1296,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1362,15 +1351,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_03_good.i
@@ -1275,7 +1275,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1284,7 +1283,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1302,7 +1300,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1338,14 +1335,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1401,15 +1390,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_04_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_04_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_05_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_05_good.i
@@ -1287,7 +1287,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1296,7 +1295,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1314,7 +1312,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1350,14 +1347,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1413,15 +1402,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_06_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_06_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_07_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_07_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_08_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_08_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_09_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_09_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_10_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_10_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_11_bad.i
@@ -1243,7 +1243,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1252,7 +1251,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1270,7 +1268,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1306,14 +1303,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1369,15 +1358,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_11_good.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_12_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_12_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_13_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_13_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_14_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_14_good.i
@@ -1283,7 +1283,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1292,7 +1291,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1310,7 +1308,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1346,14 +1343,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1409,15 +1398,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_15_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_15_good.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_16_bad.i
@@ -1244,7 +1244,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1253,7 +1252,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1271,7 +1269,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1307,14 +1304,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1370,15 +1359,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_16_good.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_17_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_17_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_18_bad.i
@@ -1240,7 +1240,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1249,7 +1248,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1267,7 +1265,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1303,14 +1300,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1366,15 +1355,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_18_good.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_21_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_21_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_22_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_22_good.i
@@ -1316,7 +1316,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1325,7 +1324,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1343,7 +1341,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1379,14 +1376,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1442,15 +1431,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_31_bad.i
@@ -1242,7 +1242,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1251,7 +1250,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1269,7 +1267,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1305,14 +1302,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1368,15 +1357,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_31_good.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_32_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_32_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_34_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_34_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_41_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_41_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_42_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_42_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_44_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_44_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_45_bad.i
@@ -1251,7 +1251,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1260,7 +1259,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1278,7 +1276,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1314,14 +1311,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1377,15 +1366,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_45_good.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_51_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_51_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_52_bad.i
@@ -1254,7 +1254,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1263,7 +1262,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1281,7 +1279,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1317,14 +1314,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1380,15 +1369,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_52_good.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_53_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_53_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_54_bad.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_54_good.i
@@ -1285,7 +1285,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1294,7 +1293,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1312,7 +1310,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1348,14 +1345,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1411,15 +1400,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_61_bad.i
@@ -1245,7 +1245,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1254,7 +1253,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1272,7 +1270,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1308,14 +1305,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1371,15 +1360,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_61_good.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_63_bad.i
@@ -1247,7 +1247,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1256,7 +1255,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1274,7 +1272,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1310,14 +1307,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1373,15 +1362,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_63_good.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_64_bad.i
@@ -1252,7 +1252,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1261,7 +1260,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1279,7 +1277,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1315,14 +1312,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1378,15 +1367,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_64_good.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_65_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_65_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_66_bad.i
@@ -1250,7 +1250,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1259,7 +1258,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1277,7 +1275,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1313,14 +1310,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1376,15 +1365,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_66_good.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_67_bad.i
@@ -1259,7 +1259,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1268,7 +1267,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1286,7 +1284,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1322,14 +1319,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1385,15 +1374,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_67_good.i
@@ -1272,7 +1272,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1281,7 +1280,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1299,7 +1297,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1335,14 +1332,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1398,15 +1387,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_68_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_malloc_68_good.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_01_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_01_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_01_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_01_good.i
@@ -1262,7 +1262,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1271,7 +1270,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1289,7 +1287,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1325,14 +1322,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1388,15 +1377,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_02_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_02_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_02_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_02_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_03_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_03_bad.i
@@ -1249,7 +1249,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1258,7 +1257,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1276,7 +1274,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1312,14 +1309,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1375,15 +1364,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_03_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_03_good.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_04_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_04_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_04_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_04_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_05_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_05_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_05_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_05_good.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_06_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_06_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_06_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_06_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_07_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_07_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_07_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_07_good.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_08_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_08_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_08_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_08_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_09_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_09_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_09_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_09_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_10_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_10_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_10_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_10_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_11_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_11_bad.i
@@ -1256,7 +1256,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1265,7 +1264,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1283,7 +1281,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1319,14 +1316,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1382,15 +1371,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_11_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_11_good.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_12_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_12_bad.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_12_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_12_good.i
@@ -1281,7 +1281,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1290,7 +1289,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1308,7 +1306,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1344,14 +1341,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1407,15 +1396,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_13_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_13_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_13_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_13_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_14_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_14_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_14_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_14_good.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_15_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_15_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_15_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_15_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_16_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_16_bad.i
@@ -1257,7 +1257,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1266,7 +1265,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1284,7 +1282,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1320,14 +1317,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1383,15 +1372,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_16_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_16_good.i
@@ -1270,7 +1270,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1279,7 +1278,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1297,7 +1295,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1333,14 +1330,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1396,15 +1385,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_17_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_17_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_17_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_17_good.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_18_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_18_bad.i
@@ -1253,7 +1253,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1262,7 +1261,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1280,7 +1278,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1316,14 +1313,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1379,15 +1368,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_18_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_18_good.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_21_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_21_bad.i
@@ -1266,7 +1266,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1275,7 +1274,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1293,7 +1291,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1329,14 +1326,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1392,15 +1381,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_21_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_21_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_22_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_22_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_22_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_22_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_31_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_31_bad.i
@@ -1255,7 +1255,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1264,7 +1263,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1282,7 +1280,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1318,14 +1315,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1381,15 +1370,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_31_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_31_good.i
@@ -1268,7 +1268,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1277,7 +1276,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1295,7 +1293,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1331,14 +1328,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1394,15 +1383,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_32_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_32_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_32_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_32_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_34_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_34_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_34_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_34_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_41_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_41_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_41_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_41_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_42_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_42_bad.i
@@ -1258,7 +1258,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1267,7 +1266,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1285,7 +1283,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1321,14 +1318,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1384,15 +1373,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_42_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_42_good.i
@@ -1271,7 +1271,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1280,7 +1279,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1298,7 +1296,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1334,14 +1331,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1397,15 +1386,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_44_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_44_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_44_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_44_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_45_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_45_bad.i
@@ -1264,7 +1264,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1273,7 +1272,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1291,7 +1289,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1327,14 +1324,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1390,15 +1379,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_45_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_45_good.i
@@ -1277,7 +1277,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1286,7 +1285,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1304,7 +1302,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1340,14 +1337,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1403,15 +1392,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_51_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_51_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_51_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_51_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_52_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_52_bad.i
@@ -1267,7 +1267,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1276,7 +1275,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1294,7 +1292,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1330,14 +1327,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1393,15 +1382,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_52_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_52_good.i
@@ -1280,7 +1280,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1289,7 +1288,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1307,7 +1305,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1343,14 +1340,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1406,15 +1395,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_53_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_53_bad.i
@@ -1279,7 +1279,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1288,7 +1287,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1306,7 +1304,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1342,14 +1339,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1405,15 +1394,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_53_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_53_good.i
@@ -1292,7 +1292,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1301,7 +1300,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1319,7 +1317,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1355,14 +1352,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1418,15 +1407,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_54_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_54_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_54_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_54_good.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_61_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_61_bad.i
@@ -1261,7 +1261,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1270,7 +1269,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1288,7 +1286,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1324,14 +1321,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1387,15 +1376,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_61_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_61_good.i
@@ -1274,7 +1274,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1283,7 +1282,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1301,7 +1299,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1337,14 +1334,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1400,15 +1389,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_63_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_63_bad.i
@@ -1260,7 +1260,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1269,7 +1268,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1287,7 +1285,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1323,14 +1320,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1386,15 +1375,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_63_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_63_good.i
@@ -1273,7 +1273,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1282,7 +1281,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1300,7 +1298,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1336,14 +1333,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1399,15 +1388,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_64_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_64_bad.i
@@ -1265,7 +1265,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1274,7 +1273,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1292,7 +1290,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1328,14 +1325,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1391,15 +1380,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_64_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_64_good.i
@@ -1278,7 +1278,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1287,7 +1286,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1305,7 +1303,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1341,14 +1338,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1404,15 +1393,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_65_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_65_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_65_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_65_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_66_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_66_bad.i
@@ -1263,7 +1263,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1272,7 +1271,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1290,7 +1288,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1326,14 +1323,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1389,15 +1378,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_66_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_66_good.i
@@ -1276,7 +1276,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1285,7 +1284,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1303,7 +1301,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1339,14 +1336,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1402,15 +1391,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_67_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_67_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_67_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_67_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_68_bad.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_68_bad.i
@@ -1269,7 +1269,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1278,7 +1277,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1296,7 +1294,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1332,14 +1329,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1395,15 +1384,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_68_good.i
+++ b/c/Juliet_Test/CWE690_NULL_Deref_From_Return---s02---CWE690_NULL_Deref_From_Return__struct_realloc_68_good.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_01_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_01_good.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_02_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_02_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_03_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_03_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_04_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_04_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_05_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_05_good.i
@@ -1578,7 +1578,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1587,7 +1586,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1605,7 +1603,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1641,14 +1638,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1704,15 +1693,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_06_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_06_good.i
@@ -1576,7 +1576,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1585,7 +1584,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1603,7 +1601,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1639,14 +1636,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1702,15 +1691,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_07_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_07_good.i
@@ -1576,7 +1576,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1585,7 +1584,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1603,7 +1601,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1639,14 +1636,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1702,15 +1691,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_08_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_08_good.i
@@ -1600,7 +1600,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1609,7 +1608,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1627,7 +1625,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1663,14 +1660,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1726,15 +1715,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_09_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_09_good.i
@@ -1574,7 +1574,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1583,7 +1582,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1601,7 +1599,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1637,14 +1634,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1700,15 +1689,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_10_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_10_good.i
@@ -1574,7 +1574,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1583,7 +1582,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1601,7 +1599,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1637,14 +1634,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1700,15 +1689,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_11_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_11_good.i
@@ -1580,7 +1580,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1589,7 +1588,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1607,7 +1605,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1643,14 +1640,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1706,15 +1695,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_12_bad.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_12_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_13_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_13_good.i
@@ -1574,7 +1574,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1583,7 +1582,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1601,7 +1599,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1637,14 +1634,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1700,15 +1689,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_14_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_14_good.i
@@ -1574,7 +1574,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1583,7 +1582,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1601,7 +1599,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1637,14 +1634,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1700,15 +1689,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_15_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_15_good.i
@@ -1599,7 +1599,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1608,7 +1607,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1626,7 +1624,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1662,14 +1659,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1725,15 +1714,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_16_bad.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_16_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_17_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_17_good.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_18_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_18_good.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_21_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_21_good.i
@@ -1600,7 +1600,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1609,7 +1608,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1627,7 +1625,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1663,14 +1660,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1726,15 +1715,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_22_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_22_good.i
@@ -1607,7 +1607,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1616,7 +1615,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1634,7 +1632,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1670,14 +1667,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1733,15 +1722,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_31_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_31_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_32_bad.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_32_good.i
@@ -1441,7 +1441,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1450,7 +1449,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1468,7 +1466,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1504,14 +1501,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1567,15 +1556,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_34_bad.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_34_good.i
@@ -1441,7 +1441,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1450,7 +1449,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1468,7 +1466,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1504,14 +1501,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1567,15 +1556,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_41_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_41_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_42_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_42_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_44_bad.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_44_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_45_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_45_good.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_51_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_51_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_52_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_52_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_53_bad.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_53_good.i
@@ -1452,7 +1452,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1461,7 +1460,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1479,7 +1477,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1515,14 +1512,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1578,15 +1567,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_54_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_54_good.i
@@ -1464,7 +1464,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1473,7 +1472,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1491,7 +1489,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1527,14 +1524,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1590,15 +1579,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_61_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_61_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_63_bad.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_63_good.i
@@ -1441,7 +1441,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1450,7 +1449,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1468,7 +1466,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1504,14 +1501,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1567,15 +1556,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_64_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_64_good.i
@@ -1443,7 +1443,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1452,7 +1451,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1470,7 +1468,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1506,14 +1503,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1569,15 +1558,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_65_bad.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_65_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_66_bad.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_66_good.i
@@ -1441,7 +1441,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1450,7 +1449,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1468,7 +1466,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1504,14 +1501,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1567,15 +1556,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_67_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_67_good.i
@@ -1450,7 +1450,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1459,7 +1458,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1477,7 +1475,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1513,14 +1510,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1576,15 +1565,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_68_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_connect_socket_68_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_01_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_01_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_02_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_02_good.i
@@ -1533,7 +1533,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1542,7 +1541,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1560,7 +1558,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1596,14 +1593,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1659,15 +1648,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_03_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_03_good.i
@@ -1533,7 +1533,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1542,7 +1541,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1560,7 +1558,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1596,14 +1593,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1659,15 +1648,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_04_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_04_good.i
@@ -1542,7 +1542,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1551,7 +1550,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1569,7 +1567,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1605,14 +1602,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1668,15 +1657,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_05_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_05_good.i
@@ -1542,7 +1542,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1551,7 +1550,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1569,7 +1567,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1605,14 +1602,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1668,15 +1657,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_06_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_06_good.i
@@ -1540,7 +1540,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1549,7 +1548,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1567,7 +1565,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1603,14 +1600,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1666,15 +1655,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_07_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_07_good.i
@@ -1540,7 +1540,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1549,7 +1548,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1567,7 +1565,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1603,14 +1600,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1666,15 +1655,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_08_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_08_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_09_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_09_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_10_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_10_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_11_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_11_good.i
@@ -1544,7 +1544,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1553,7 +1552,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1571,7 +1569,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1607,14 +1604,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1670,15 +1659,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_12_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_12_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_13_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_13_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_14_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_14_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_15_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_15_good.i
@@ -1563,7 +1563,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1572,7 +1571,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1590,7 +1588,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1626,14 +1623,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1689,15 +1678,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_16_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_16_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_17_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_17_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_18_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_18_good.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_21_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_21_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_22_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_22_good.i
@@ -1571,7 +1571,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1580,7 +1579,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1598,7 +1596,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1634,14 +1631,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1697,15 +1686,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_31_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_31_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_32_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_32_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_34_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_34_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_41_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_41_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_42_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_42_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_44_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_44_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_45_bad.i
@@ -1388,7 +1388,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1397,7 +1396,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1415,7 +1413,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1451,14 +1448,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1514,15 +1503,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_45_good.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_51_bad.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_51_good.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_52_bad.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_52_good.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_53_bad.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_53_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_54_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_54_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_61_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_61_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_63_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_63_good.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_64_bad.i
@@ -1386,7 +1386,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1395,7 +1394,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1413,7 +1411,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1449,14 +1446,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1512,15 +1501,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_64_good.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_65_bad.i
@@ -1384,7 +1384,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1393,7 +1392,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1411,7 +1409,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1447,14 +1444,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1510,15 +1499,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_65_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_66_bad.i
@@ -1390,7 +1390,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1399,7 +1398,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1417,7 +1415,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1453,14 +1450,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1516,15 +1505,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_66_good.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_67_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_67_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_68_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_console_68_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_01_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_01_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_02_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_02_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_03_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_03_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_04_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_04_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_05_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_05_good.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_06_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_06_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_07_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_07_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_08_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_08_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_09_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_09_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_10_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_10_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_11_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_11_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_12_bad.i
@@ -1348,7 +1348,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1357,7 +1356,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1375,7 +1373,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1411,14 +1408,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1474,15 +1463,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_12_good.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_13_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_13_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_14_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_14_good.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_15_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_15_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_16_bad.i
@@ -1303,7 +1303,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1312,7 +1311,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1330,7 +1328,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1366,14 +1363,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1429,15 +1418,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_16_good.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_17_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_17_good.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_18_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_18_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_21_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_21_good.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_22_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_22_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_31_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_31_good.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_32_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_32_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_34_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_34_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_41_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_41_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_42_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_42_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_44_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_44_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_45_bad.i
@@ -1310,7 +1310,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1319,7 +1318,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1337,7 +1335,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1373,14 +1370,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1436,15 +1425,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_45_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_51_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_51_good.i
@@ -1337,7 +1337,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1346,7 +1345,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1364,7 +1362,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1400,14 +1397,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1463,15 +1452,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_52_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_52_good.i
@@ -1343,7 +1343,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1352,7 +1351,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1370,7 +1368,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1406,14 +1403,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1469,15 +1458,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_53_bad.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_53_good.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_54_bad.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_54_good.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_61_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_61_good.i
@@ -1336,7 +1336,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1345,7 +1344,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1363,7 +1361,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1399,14 +1396,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1462,15 +1451,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_63_bad.i
@@ -1306,7 +1306,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1315,7 +1314,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1333,7 +1331,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1369,14 +1366,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1432,15 +1421,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_63_good.i
@@ -1338,7 +1338,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1347,7 +1346,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1365,7 +1363,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1401,14 +1398,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1464,15 +1453,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_64_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_64_good.i
@@ -1340,7 +1340,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1349,7 +1348,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1367,7 +1365,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1403,14 +1400,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1466,15 +1455,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_65_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_65_good.i
@@ -1339,7 +1339,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1348,7 +1347,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1366,7 +1364,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1402,14 +1399,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1465,15 +1454,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_66_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_66_good.i
@@ -1341,7 +1341,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1350,7 +1349,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1368,7 +1366,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1404,14 +1401,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1467,15 +1456,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_67_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_67_good.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_68_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_environment_68_good.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_01_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_01_good.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_02_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_02_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_03_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_03_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_04_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_04_good.i
@@ -1523,7 +1523,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1532,7 +1531,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1550,7 +1548,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1586,14 +1583,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1649,15 +1638,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_05_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_05_good.i
@@ -1523,7 +1523,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1532,7 +1531,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1550,7 +1548,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1586,14 +1583,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1649,15 +1638,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_06_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_06_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_07_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_07_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_08_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_08_good.i
@@ -1545,7 +1545,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1554,7 +1553,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1572,7 +1570,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1608,14 +1605,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1671,15 +1660,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_09_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_09_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_10_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_10_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_11_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_11_good.i
@@ -1525,7 +1525,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1534,7 +1533,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1552,7 +1550,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1588,14 +1585,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1651,15 +1640,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_12_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_12_good.i
@@ -1448,7 +1448,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1457,7 +1456,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1475,7 +1473,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1511,14 +1508,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1574,15 +1563,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_13_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_13_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_14_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_14_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_15_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_15_good.i
@@ -1544,7 +1544,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1553,7 +1552,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1571,7 +1569,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1607,14 +1604,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1670,15 +1659,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_16_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_16_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_17_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_17_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_18_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_18_good.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_21_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_21_good.i
@@ -1545,7 +1545,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1554,7 +1553,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1572,7 +1570,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1608,14 +1605,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1671,15 +1660,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_22_bad.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_22_good.i
@@ -1552,7 +1552,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1561,7 +1560,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1579,7 +1577,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1615,14 +1612,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1678,15 +1667,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_31_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_31_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_32_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_32_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_34_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_34_good.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_41_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_41_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_42_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_42_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_44_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_44_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_45_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_45_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_51_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_51_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_52_bad.i
@@ -1383,7 +1383,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1392,7 +1391,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1410,7 +1408,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1446,14 +1443,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1509,15 +1498,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_52_good.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_53_bad.i
@@ -1395,7 +1395,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1404,7 +1403,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1422,7 +1420,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1458,14 +1455,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1521,15 +1510,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_53_good.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_54_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_54_good.i
@@ -1440,7 +1440,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1449,7 +1448,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1467,7 +1465,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1503,14 +1500,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1566,15 +1555,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_61_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_61_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_63_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_63_good.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_64_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_64_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_65_bad.i
@@ -1376,7 +1376,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1385,7 +1384,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1403,7 +1401,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1439,14 +1436,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1502,15 +1491,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_65_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_66_bad.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_66_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_67_bad.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_67_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_68_bad.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_file_68_good.i
@@ -1417,7 +1417,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1426,7 +1425,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1444,7 +1442,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1480,14 +1477,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1543,15 +1532,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_01_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_01_good.i
@@ -1314,7 +1314,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1323,7 +1322,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1341,7 +1339,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1377,14 +1374,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1440,15 +1429,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_02_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_02_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_03_bad.i
@@ -1282,7 +1282,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1291,7 +1290,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1309,7 +1307,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1345,14 +1342,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1408,15 +1397,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_03_good.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_04_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_04_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_05_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_05_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_06_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_06_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_07_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_07_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_08_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_08_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_09_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_09_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_10_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_10_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_11_bad.i
@@ -1289,7 +1289,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1298,7 +1297,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1316,7 +1314,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1352,14 +1349,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1415,15 +1404,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_11_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_12_bad.i
@@ -1335,7 +1335,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1344,7 +1343,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1362,7 +1360,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1398,14 +1395,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1461,15 +1450,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_12_good.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_13_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_13_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_14_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_14_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_15_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_15_good.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_16_bad.i
@@ -1290,7 +1290,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1299,7 +1298,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1317,7 +1315,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1353,14 +1350,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1416,15 +1405,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_16_good.i
@@ -1322,7 +1322,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1331,7 +1330,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1349,7 +1347,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1385,14 +1382,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1448,15 +1437,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_17_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_17_good.i
@@ -1331,7 +1331,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1340,7 +1339,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1358,7 +1356,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1394,14 +1391,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1457,15 +1446,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_18_bad.i
@@ -1286,7 +1286,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1295,7 +1294,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1313,7 +1311,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1349,14 +1346,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1412,15 +1401,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_18_good.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_21_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_21_good.i
@@ -1436,7 +1436,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1445,7 +1444,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1463,7 +1461,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1499,14 +1496,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1562,15 +1551,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_22_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_22_good.i
@@ -1443,7 +1443,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1452,7 +1451,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1470,7 +1468,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1506,14 +1503,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1569,15 +1558,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_31_bad.i
@@ -1288,7 +1288,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1297,7 +1296,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1315,7 +1313,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1351,14 +1348,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1414,15 +1403,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_31_good.i
@@ -1320,7 +1320,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1329,7 +1328,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1347,7 +1345,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1383,14 +1380,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1446,15 +1435,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_32_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_32_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_34_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_34_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_41_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_41_good.i
@@ -1321,7 +1321,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1330,7 +1329,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1348,7 +1346,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1384,14 +1381,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1447,15 +1436,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_42_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_42_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_44_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_44_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_45_bad.i
@@ -1297,7 +1297,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1306,7 +1305,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1324,7 +1322,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1360,14 +1357,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1423,15 +1412,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_45_good.i
@@ -1329,7 +1329,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1338,7 +1337,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1356,7 +1354,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1392,14 +1389,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1455,15 +1444,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_51_bad.i
@@ -1294,7 +1294,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1303,7 +1302,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1321,7 +1319,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1357,14 +1354,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1420,15 +1409,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_51_good.i
@@ -1324,7 +1324,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1333,7 +1332,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1351,7 +1349,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1387,14 +1384,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1450,15 +1439,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_52_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_52_good.i
@@ -1330,7 +1330,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1339,7 +1338,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1357,7 +1355,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1393,14 +1390,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1456,15 +1445,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_53_bad.i
@@ -1312,7 +1312,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1321,7 +1320,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1339,7 +1337,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1375,14 +1372,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1438,15 +1427,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_53_good.i
@@ -1342,7 +1342,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1351,7 +1350,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1369,7 +1367,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1405,14 +1402,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1468,15 +1457,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_54_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_54_good.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_61_bad.i
@@ -1291,7 +1291,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1300,7 +1299,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1318,7 +1316,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1354,14 +1351,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1417,15 +1406,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_61_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_63_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_63_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_64_bad.i
@@ -1295,7 +1295,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1304,7 +1303,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1322,7 +1320,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1358,14 +1355,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1421,15 +1410,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_64_good.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_65_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_65_good.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_66_bad.i
@@ -1296,7 +1296,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1305,7 +1304,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1323,7 +1321,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1359,14 +1356,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1422,15 +1411,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_66_good.i
@@ -1328,7 +1328,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1337,7 +1336,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1355,7 +1353,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1391,14 +1388,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1454,15 +1443,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_67_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_67_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_68_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_fixed_string_68_good.i
@@ -1334,7 +1334,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1343,7 +1342,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1361,7 +1359,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1397,14 +1394,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1460,15 +1449,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_01_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_01_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_02_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_02_good.i
@@ -1604,7 +1604,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1613,7 +1612,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1631,7 +1629,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1667,14 +1664,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1730,15 +1719,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_03_bad.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_03_good.i
@@ -1604,7 +1604,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1613,7 +1612,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1631,7 +1629,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1667,14 +1664,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1730,15 +1719,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_04_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_04_good.i
@@ -1613,7 +1613,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1622,7 +1621,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1640,7 +1638,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1676,14 +1673,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1739,15 +1728,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_05_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_05_good.i
@@ -1613,7 +1613,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1622,7 +1621,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1640,7 +1638,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1676,14 +1673,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1739,15 +1728,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_06_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_06_good.i
@@ -1611,7 +1611,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1620,7 +1619,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1638,7 +1636,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1674,14 +1671,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1737,15 +1726,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_07_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_07_good.i
@@ -1611,7 +1611,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1620,7 +1619,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1638,7 +1636,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1674,14 +1671,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1737,15 +1726,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_08_bad.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_08_good.i
@@ -1635,7 +1635,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1644,7 +1643,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1662,7 +1660,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1698,14 +1695,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1761,15 +1750,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_09_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_09_good.i
@@ -1609,7 +1609,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1618,7 +1617,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1636,7 +1634,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1672,14 +1669,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1735,15 +1724,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_10_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_10_good.i
@@ -1609,7 +1609,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1618,7 +1617,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1636,7 +1634,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1672,14 +1669,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1735,15 +1724,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_11_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_11_good.i
@@ -1615,7 +1615,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1624,7 +1623,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1642,7 +1640,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1678,14 +1675,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1741,15 +1730,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_12_bad.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_12_good.i
@@ -1497,7 +1497,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1506,7 +1505,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1524,7 +1522,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1560,14 +1557,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1623,15 +1612,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_13_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_13_good.i
@@ -1609,7 +1609,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1618,7 +1617,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1636,7 +1634,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1672,14 +1669,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1735,15 +1724,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_14_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_14_good.i
@@ -1609,7 +1609,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1618,7 +1617,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1636,7 +1634,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1672,14 +1669,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1735,15 +1724,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_15_bad.i
@@ -1429,7 +1429,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1438,7 +1437,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1456,7 +1454,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1492,14 +1489,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1555,15 +1544,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_15_good.i
@@ -1634,7 +1634,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1643,7 +1642,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1661,7 +1659,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1697,14 +1694,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1760,15 +1749,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_16_bad.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_16_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_17_bad.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_17_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_18_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_18_good.i
@@ -1450,7 +1450,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1459,7 +1458,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1477,7 +1475,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1513,14 +1510,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1576,15 +1565,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_21_bad.i
@@ -1431,7 +1431,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1440,7 +1439,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1458,7 +1456,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1494,14 +1491,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1557,15 +1546,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_21_good.i
@@ -1635,7 +1635,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1644,7 +1643,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1662,7 +1660,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1698,14 +1695,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1761,15 +1750,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_22_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_22_good.i
@@ -1642,7 +1642,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1651,7 +1650,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1669,7 +1667,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1705,14 +1702,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1768,15 +1757,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_31_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_31_good.i
@@ -1452,7 +1452,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1461,7 +1460,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1479,7 +1477,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1515,14 +1512,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1578,15 +1567,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_32_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_32_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_34_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_34_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_41_bad.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_41_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_42_bad.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_42_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_44_bad.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_44_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_45_bad.i
@@ -1429,7 +1429,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1438,7 +1437,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1456,7 +1454,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1492,14 +1489,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1555,15 +1544,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_45_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_51_bad.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_51_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_52_bad.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_52_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_53_bad.i
@@ -1444,7 +1444,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1453,7 +1452,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1471,7 +1469,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1507,14 +1504,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1570,15 +1559,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_53_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_54_bad.i
@@ -1456,7 +1456,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1465,7 +1464,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1483,7 +1481,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1519,14 +1516,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1582,15 +1571,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_54_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_61_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_61_good.i
@@ -1458,7 +1458,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1467,7 +1466,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1485,7 +1483,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1521,14 +1518,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1584,15 +1573,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_63_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_63_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_64_bad.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_64_good.i
@@ -1459,7 +1459,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1468,7 +1467,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1486,7 +1484,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1522,14 +1519,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1585,15 +1574,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_65_bad.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_65_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_66_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_66_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_67_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_67_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_68_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE761_Free_Pointer_Not_at_Start_of_Buffer---CWE761_Free_Pointer_Not_at_Start_of_Buffer__char_listen_socket_68_good.i
@@ -1466,7 +1466,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1475,7 +1474,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1493,7 +1491,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1529,14 +1526,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1592,15 +1581,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_01_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_01_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_01_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_01_good.i
@@ -1482,7 +1482,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1491,7 +1490,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1509,7 +1507,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1545,14 +1542,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1608,15 +1597,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_02_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_02_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_02_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_02_good.i
@@ -1679,7 +1679,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1688,7 +1687,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1706,7 +1704,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1742,14 +1739,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1805,15 +1794,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_03_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_03_bad.i
@@ -1393,7 +1393,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1402,7 +1401,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1420,7 +1418,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1456,14 +1453,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1519,15 +1508,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_03_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_03_good.i
@@ -1679,7 +1679,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1688,7 +1687,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1706,7 +1704,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1742,14 +1739,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1805,15 +1794,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_04_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_04_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_04_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_04_good.i
@@ -1700,7 +1700,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1709,7 +1708,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1727,7 +1725,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1763,14 +1760,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1826,15 +1815,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_05_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_05_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_05_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_05_good.i
@@ -1699,7 +1699,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1708,7 +1707,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1726,7 +1724,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1762,14 +1759,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1825,15 +1814,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_06_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_06_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_06_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_06_good.i
@@ -1698,7 +1698,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1707,7 +1706,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1725,7 +1723,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1761,14 +1758,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1824,15 +1813,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_07_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_07_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_07_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_07_good.i
@@ -1697,7 +1697,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1706,7 +1705,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1724,7 +1722,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1760,14 +1757,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1823,15 +1812,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_08_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_08_bad.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_08_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_08_good.i
@@ -1739,7 +1739,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1748,7 +1747,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1766,7 +1764,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1802,14 +1799,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1865,15 +1854,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_09_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_09_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_09_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_09_good.i
@@ -1696,7 +1696,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1705,7 +1704,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1723,7 +1721,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1759,14 +1756,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1822,15 +1811,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_10_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_10_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_10_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_10_good.i
@@ -1695,7 +1695,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1704,7 +1703,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1722,7 +1720,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1758,14 +1755,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1821,15 +1810,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_11_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_11_bad.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_11_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_11_good.i
@@ -1719,7 +1719,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1728,7 +1727,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1746,7 +1744,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1782,14 +1779,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1845,15 +1834,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_12_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_12_bad.i
@@ -1469,7 +1469,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1478,7 +1477,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1496,7 +1494,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1532,14 +1529,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1595,15 +1584,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_12_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_12_good.i
@@ -1670,7 +1670,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1679,7 +1678,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1697,7 +1695,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1733,14 +1730,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1796,15 +1785,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_13_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_13_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_13_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_13_good.i
@@ -1696,7 +1696,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1705,7 +1704,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1723,7 +1721,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1759,14 +1756,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1822,15 +1811,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_14_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_14_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_14_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_14_good.i
@@ -1695,7 +1695,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1704,7 +1703,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1722,7 +1720,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1758,14 +1755,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1821,15 +1810,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_15_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_15_bad.i
@@ -1423,7 +1423,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1432,7 +1431,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1450,7 +1448,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1486,14 +1483,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1549,15 +1538,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_15_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_15_good.i
@@ -1799,7 +1799,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1808,7 +1807,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1826,7 +1824,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1862,14 +1859,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1925,15 +1914,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_16_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_16_bad.i
@@ -1409,7 +1409,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1418,7 +1417,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1436,7 +1434,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1472,14 +1469,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1535,15 +1524,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_16_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_16_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_17_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_17_bad.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_17_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_17_good.i
@@ -1550,7 +1550,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1559,7 +1558,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1577,7 +1575,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1613,14 +1610,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1676,15 +1665,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_18_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_18_bad.i
@@ -1401,7 +1401,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1410,7 +1409,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1428,7 +1426,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1464,14 +1461,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1527,15 +1516,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_18_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_18_good.i
@@ -1498,7 +1498,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1507,7 +1506,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1525,7 +1523,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1561,14 +1558,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1624,15 +1613,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_21_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_21_bad.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_21_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_21_good.i
@@ -1649,7 +1649,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1658,7 +1657,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1676,7 +1674,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1712,14 +1709,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1775,15 +1764,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_22_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_22_bad.i
@@ -1411,7 +1411,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1420,7 +1419,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1438,7 +1436,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1474,14 +1471,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1537,15 +1526,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_22_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_22_good.i
@@ -1659,7 +1659,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1668,7 +1667,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1686,7 +1684,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1722,14 +1719,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1785,15 +1774,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_31_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_31_bad.i
@@ -1399,7 +1399,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1408,7 +1407,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1426,7 +1424,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1462,14 +1459,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1525,15 +1514,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_31_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_31_good.i
@@ -1494,7 +1494,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1503,7 +1502,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1521,7 +1519,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1557,14 +1554,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1620,15 +1609,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_32_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_32_bad.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_32_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_32_good.i
@@ -1510,7 +1510,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1519,7 +1518,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1537,7 +1535,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1573,14 +1570,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1636,15 +1625,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_34_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_34_bad.i
@@ -1407,7 +1407,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1416,7 +1415,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1434,7 +1432,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1470,14 +1467,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1533,15 +1522,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_34_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_34_good.i
@@ -1503,7 +1503,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1512,7 +1511,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1530,7 +1528,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1566,14 +1563,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1629,15 +1618,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_41_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_41_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_41_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_41_good.i
@@ -1496,7 +1496,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1505,7 +1504,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1523,7 +1521,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1559,14 +1556,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1622,15 +1611,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_42_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_42_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_42_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_42_good.i
@@ -1500,7 +1500,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1509,7 +1508,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1527,7 +1525,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1563,14 +1560,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1626,15 +1615,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_44_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_44_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_44_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_44_good.i
@@ -1500,7 +1500,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1509,7 +1508,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1527,7 +1525,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1563,14 +1560,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1626,15 +1615,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_45_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_45_bad.i
@@ -1408,7 +1408,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1417,7 +1416,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1435,7 +1433,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1471,14 +1468,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1534,15 +1523,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_45_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_45_good.i
@@ -1512,7 +1512,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1521,7 +1520,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1539,7 +1537,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1575,14 +1572,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1638,15 +1627,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_51_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_51_bad.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_51_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_51_good.i
@@ -1496,7 +1496,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1505,7 +1504,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1523,7 +1521,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1559,14 +1556,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1622,15 +1611,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_52_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_52_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_52_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_52_good.i
@@ -1520,7 +1520,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1529,7 +1528,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1547,7 +1545,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1583,14 +1580,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1646,15 +1635,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_53_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_53_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_53_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_53_good.i
@@ -1538,7 +1538,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1547,7 +1546,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1565,7 +1563,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1601,14 +1598,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1664,15 +1653,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_54_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_54_bad.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_54_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_54_good.i
@@ -1556,7 +1556,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1565,7 +1564,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1583,7 +1581,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1619,14 +1616,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1682,15 +1671,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_61_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_61_bad.i
@@ -1405,7 +1405,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1414,7 +1413,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1432,7 +1430,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1468,14 +1465,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1531,15 +1520,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_61_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_61_good.i
@@ -1506,7 +1506,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1515,7 +1514,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1533,7 +1531,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1569,14 +1566,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1632,15 +1621,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_63_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_63_bad.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_63_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_63_good.i
@@ -1504,7 +1504,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1513,7 +1512,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1531,7 +1529,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1567,14 +1564,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1630,15 +1619,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_64_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_64_bad.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_64_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_64_good.i
@@ -1508,7 +1508,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1517,7 +1516,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1535,7 +1533,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1571,14 +1568,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1634,15 +1623,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_65_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_65_bad.i
@@ -1402,7 +1402,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1411,7 +1410,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1429,7 +1427,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1465,14 +1462,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1528,15 +1517,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_65_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_65_good.i
@@ -1500,7 +1500,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1509,7 +1508,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1527,7 +1525,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1563,14 +1560,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1626,15 +1615,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_66_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_66_bad.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_66_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_66_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_67_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_67_bad.i
@@ -1413,7 +1413,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1422,7 +1421,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1440,7 +1438,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1476,14 +1473,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1539,15 +1528,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_67_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_67_good.i
@@ -1516,7 +1516,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1525,7 +1524,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1543,7 +1541,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1579,14 +1576,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1642,15 +1631,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_68_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_68_bad.i
@@ -1415,7 +1415,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1424,7 +1423,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1442,7 +1440,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1478,14 +1475,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1541,15 +1530,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_68_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_connect_socket_68_good.i
@@ -1520,7 +1520,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1529,7 +1528,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1547,7 +1545,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1583,14 +1580,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1646,15 +1635,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_01_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_01_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_01_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_01_good.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_02_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_02_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_02_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_02_good.i
@@ -1612,7 +1612,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1621,7 +1620,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1639,7 +1637,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1675,14 +1672,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1738,15 +1727,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_03_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_03_bad.i
@@ -1357,7 +1357,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1366,7 +1365,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1384,7 +1382,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1420,14 +1417,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1483,15 +1472,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_03_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_03_good.i
@@ -1612,7 +1612,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1621,7 +1620,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1639,7 +1637,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1675,14 +1672,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1738,15 +1727,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_04_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_04_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_04_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_04_good.i
@@ -1633,7 +1633,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1642,7 +1641,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1660,7 +1658,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1696,14 +1693,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1759,15 +1748,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_05_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_05_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_05_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_05_good.i
@@ -1632,7 +1632,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1641,7 +1640,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1659,7 +1657,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1695,14 +1692,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1758,15 +1747,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_06_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_06_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_06_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_06_good.i
@@ -1631,7 +1631,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1640,7 +1639,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1658,7 +1656,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1694,14 +1691,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1757,15 +1746,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_07_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_07_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_07_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_07_good.i
@@ -1630,7 +1630,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1639,7 +1638,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1657,7 +1655,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1693,14 +1690,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1756,15 +1745,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_08_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_08_bad.i
@@ -1377,7 +1377,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1386,7 +1385,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1404,7 +1402,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1440,14 +1437,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1503,15 +1492,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_08_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_08_good.i
@@ -1672,7 +1672,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1681,7 +1680,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1699,7 +1697,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1735,14 +1732,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1798,15 +1787,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_09_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_09_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_09_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_09_good.i
@@ -1629,7 +1629,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1638,7 +1637,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1656,7 +1654,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1692,14 +1689,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1755,15 +1744,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_10_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_10_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_10_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_10_good.i
@@ -1628,7 +1628,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1637,7 +1636,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1655,7 +1653,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1691,14 +1688,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1754,15 +1743,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_11_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_11_bad.i
@@ -1367,7 +1367,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1376,7 +1375,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1394,7 +1392,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1430,14 +1427,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1493,15 +1482,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_11_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_11_good.i
@@ -1652,7 +1652,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1661,7 +1660,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1679,7 +1677,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1715,14 +1712,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1778,15 +1767,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_12_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_12_bad.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_12_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_12_good.i
@@ -1603,7 +1603,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1612,7 +1611,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1630,7 +1628,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1666,14 +1663,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1729,15 +1718,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_13_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_13_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_13_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_13_good.i
@@ -1629,7 +1629,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1638,7 +1637,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1656,7 +1654,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1692,14 +1689,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1755,15 +1744,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_14_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_14_bad.i
@@ -1361,7 +1361,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1370,7 +1369,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1388,7 +1386,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1424,14 +1421,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1487,15 +1476,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_14_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_14_good.i
@@ -1628,7 +1628,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1637,7 +1636,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1655,7 +1653,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1691,14 +1688,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1754,15 +1743,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_15_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_15_bad.i
@@ -1387,7 +1387,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1396,7 +1395,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1414,7 +1412,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1450,14 +1447,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1513,15 +1502,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_15_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_15_good.i
@@ -1732,7 +1732,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1741,7 +1740,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1759,7 +1757,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1795,14 +1792,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1858,15 +1847,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_16_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_16_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_16_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_16_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_17_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_17_bad.i
@@ -1391,7 +1391,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1400,7 +1399,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1418,7 +1416,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1454,14 +1451,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1517,15 +1506,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_17_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_17_good.i
@@ -1514,7 +1514,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1523,7 +1522,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1541,7 +1539,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1577,14 +1574,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1640,15 +1629,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_18_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_18_bad.i
@@ -1365,7 +1365,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1374,7 +1373,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1392,7 +1390,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1428,14 +1425,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1491,15 +1480,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_18_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_18_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_21_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_21_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_21_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_21_good.i
@@ -1582,7 +1582,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1591,7 +1590,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1609,7 +1607,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1645,14 +1642,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1708,15 +1697,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_22_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_22_bad.i
@@ -1375,7 +1375,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1384,7 +1383,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1402,7 +1400,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1438,14 +1435,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1501,15 +1490,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_22_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_22_good.i
@@ -1592,7 +1592,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1601,7 +1600,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1619,7 +1617,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1655,14 +1652,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1718,15 +1707,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_31_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_31_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_31_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_31_good.i
@@ -1458,7 +1458,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1467,7 +1466,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1485,7 +1483,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1521,14 +1518,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1584,15 +1573,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_32_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_32_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_32_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_32_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_34_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_34_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_34_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_34_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_41_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_41_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_41_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_41_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_42_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_42_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_42_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_42_good.i
@@ -1464,7 +1464,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1473,7 +1472,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1491,7 +1489,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1527,14 +1524,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1590,15 +1579,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_44_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_44_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_44_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_44_good.i
@@ -1464,7 +1464,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1473,7 +1472,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1491,7 +1489,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1527,14 +1524,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1590,15 +1579,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_45_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_45_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_45_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_45_good.i
@@ -1476,7 +1476,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1485,7 +1484,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1503,7 +1501,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1539,14 +1536,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1602,15 +1591,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_51_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_51_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_51_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_51_good.i
@@ -1460,7 +1460,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1469,7 +1468,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1487,7 +1485,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1523,14 +1520,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1586,15 +1575,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_52_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_52_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_52_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_52_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_53_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_53_bad.i
@@ -1385,7 +1385,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1394,7 +1393,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1412,7 +1410,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1448,14 +1445,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1511,15 +1500,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_53_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_53_good.i
@@ -1502,7 +1502,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1511,7 +1510,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1529,7 +1527,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1565,14 +1562,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1628,15 +1617,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_54_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_54_bad.i
@@ -1397,7 +1397,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1406,7 +1405,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1424,7 +1422,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1460,14 +1457,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1523,15 +1512,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_54_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_54_good.i
@@ -1526,7 +1526,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1535,7 +1534,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1553,7 +1551,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1589,14 +1586,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1652,15 +1641,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_61_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_61_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_61_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_61_good.i
@@ -1470,7 +1470,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1479,7 +1478,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1497,7 +1495,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1533,14 +1530,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1596,15 +1585,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_63_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_63_bad.i
@@ -1368,7 +1368,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1377,7 +1376,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1395,7 +1393,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1431,14 +1428,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1494,15 +1483,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_63_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_63_good.i
@@ -1468,7 +1468,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1477,7 +1476,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1495,7 +1493,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1531,14 +1528,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1594,15 +1583,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_64_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_64_bad.i
@@ -1373,7 +1373,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1382,7 +1381,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1400,7 +1398,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1436,14 +1433,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1499,15 +1488,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_64_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_64_good.i
@@ -1478,7 +1478,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1487,7 +1486,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1505,7 +1503,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1541,14 +1538,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1604,15 +1593,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_65_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_65_bad.i
@@ -1369,7 +1369,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1378,7 +1377,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1396,7 +1394,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1432,14 +1429,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1495,15 +1484,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_65_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_65_good.i
@@ -1470,7 +1470,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1479,7 +1478,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1497,7 +1495,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1533,14 +1530,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1596,15 +1585,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_66_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_66_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_66_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_66_good.i
@@ -1474,7 +1474,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1483,7 +1482,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1501,7 +1499,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1537,14 +1534,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1600,15 +1589,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_67_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_67_bad.i
@@ -1380,7 +1380,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1389,7 +1388,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1407,7 +1405,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1443,14 +1440,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1506,15 +1495,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_67_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_67_good.i
@@ -1486,7 +1486,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1495,7 +1494,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1513,7 +1511,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1549,14 +1546,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1612,15 +1601,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_68_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_68_bad.i
@@ -1379,7 +1379,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1388,7 +1387,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1406,7 +1404,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1442,14 +1439,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1505,15 +1494,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_68_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fgets_68_good.i
@@ -1484,7 +1484,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1493,7 +1492,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1511,7 +1509,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1547,14 +1544,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1610,15 +1599,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_01_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_01_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_01_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_01_good.i
@@ -1433,7 +1433,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1442,7 +1441,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1460,7 +1458,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1496,14 +1493,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1559,15 +1548,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_02_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_02_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_02_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_02_good.i
@@ -1589,7 +1589,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1598,7 +1597,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1616,7 +1614,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1652,14 +1649,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1715,15 +1704,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_03_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_03_bad.i
@@ -1344,7 +1344,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1353,7 +1352,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1371,7 +1369,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1407,14 +1404,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1470,15 +1459,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_03_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_03_good.i
@@ -1589,7 +1589,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1598,7 +1597,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1616,7 +1614,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1652,14 +1649,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1715,15 +1704,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_04_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_04_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_04_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_04_good.i
@@ -1608,7 +1608,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1617,7 +1616,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1635,7 +1633,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1671,14 +1668,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1734,15 +1723,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_05_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_05_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_05_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_05_good.i
@@ -1607,7 +1607,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1616,7 +1615,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1634,7 +1632,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1670,14 +1667,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1733,15 +1722,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_06_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_06_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_06_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_06_good.i
@@ -1606,7 +1606,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1615,7 +1614,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1633,7 +1631,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1669,14 +1666,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1732,15 +1721,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_07_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_07_bad.i
@@ -1349,7 +1349,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1358,7 +1357,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1376,7 +1374,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1412,14 +1409,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1475,15 +1464,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_07_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_07_good.i
@@ -1605,7 +1605,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1614,7 +1613,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1632,7 +1630,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1668,14 +1665,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1731,15 +1720,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_08_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_08_bad.i
@@ -1363,7 +1363,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1372,7 +1371,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1390,7 +1388,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1426,14 +1423,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1489,15 +1478,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_08_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_08_good.i
@@ -1647,7 +1647,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1656,7 +1655,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1674,7 +1672,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1710,14 +1707,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1773,15 +1762,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_09_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_09_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_09_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_09_good.i
@@ -1604,7 +1604,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1613,7 +1612,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1631,7 +1629,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1667,14 +1664,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1730,15 +1719,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_10_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_10_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_10_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_10_good.i
@@ -1603,7 +1603,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1612,7 +1611,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1630,7 +1628,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1666,14 +1663,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1729,15 +1718,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_11_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_11_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_11_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_11_good.i
@@ -1627,7 +1627,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1636,7 +1635,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1654,7 +1652,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1690,14 +1687,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1753,15 +1742,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_12_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_12_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_12_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_12_good.i
@@ -1579,7 +1579,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1588,7 +1587,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1606,7 +1604,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1642,14 +1639,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1705,15 +1694,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_13_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_13_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_13_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_13_good.i
@@ -1604,7 +1604,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1613,7 +1612,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1631,7 +1629,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1667,14 +1664,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1730,15 +1719,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_14_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_14_bad.i
@@ -1347,7 +1347,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1356,7 +1355,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1374,7 +1372,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1410,14 +1407,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1473,15 +1462,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_14_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_14_good.i
@@ -1603,7 +1603,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1612,7 +1611,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1630,7 +1628,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1666,14 +1663,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1729,15 +1718,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_15_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_15_bad.i
@@ -1374,7 +1374,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1383,7 +1382,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1401,7 +1399,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1437,14 +1434,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1500,15 +1489,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_15_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_15_good.i
@@ -1709,7 +1709,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1718,7 +1717,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1736,7 +1734,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1772,14 +1769,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1835,15 +1824,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_16_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_16_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_16_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_16_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_17_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_17_bad.i
@@ -1378,7 +1378,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1387,7 +1386,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1405,7 +1403,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1441,14 +1438,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1504,15 +1493,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_17_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_17_good.i
@@ -1501,7 +1501,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1510,7 +1509,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1528,7 +1526,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1564,14 +1561,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1627,15 +1616,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_18_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_18_bad.i
@@ -1352,7 +1352,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1361,7 +1360,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1379,7 +1377,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1415,14 +1412,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1478,15 +1467,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_18_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_18_good.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_21_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_21_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_21_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_21_good.i
@@ -1559,7 +1559,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1568,7 +1567,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1586,7 +1584,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1622,14 +1619,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1685,15 +1674,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_22_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_22_bad.i
@@ -1362,7 +1362,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1371,7 +1370,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1389,7 +1387,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1425,14 +1422,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1488,15 +1477,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_22_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_22_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_31_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_31_bad.i
@@ -1350,7 +1350,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1359,7 +1358,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1377,7 +1375,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1413,14 +1410,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1476,15 +1465,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_31_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_31_good.i
@@ -1445,7 +1445,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1454,7 +1453,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1472,7 +1470,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1508,14 +1505,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1571,15 +1560,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_32_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_32_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_32_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_32_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_34_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_34_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_34_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_34_good.i
@@ -1454,7 +1454,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1463,7 +1462,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1481,7 +1479,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1517,14 +1514,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1580,15 +1569,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_41_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_41_bad.i
@@ -1351,7 +1351,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1360,7 +1359,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1378,7 +1376,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1414,14 +1411,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1477,15 +1466,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_41_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_41_good.i
@@ -1447,7 +1447,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1456,7 +1455,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1474,7 +1472,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1510,14 +1507,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1573,15 +1562,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_42_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_42_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_42_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_42_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_44_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_44_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_44_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_44_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_45_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_45_bad.i
@@ -1359,7 +1359,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1368,7 +1367,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1386,7 +1384,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1422,14 +1419,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1485,15 +1474,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_45_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_45_good.i
@@ -1463,7 +1463,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1472,7 +1471,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1490,7 +1488,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1526,14 +1523,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1589,15 +1578,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_51_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_51_bad.i
@@ -1354,7 +1354,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1363,7 +1362,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1381,7 +1379,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1417,14 +1414,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1480,15 +1469,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_51_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_51_good.i
@@ -1453,7 +1453,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1462,7 +1461,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1480,7 +1478,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1516,14 +1513,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1579,15 +1568,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_52_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_52_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_52_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_52_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_53_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_53_bad.i
@@ -1372,7 +1372,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1381,7 +1380,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1399,7 +1397,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1435,14 +1432,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1498,15 +1487,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_53_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_53_good.i
@@ -1489,7 +1489,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1498,7 +1497,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1516,7 +1514,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1552,14 +1549,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1615,15 +1604,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_54_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_54_bad.i
@@ -1381,7 +1381,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1390,7 +1389,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1408,7 +1406,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1444,14 +1441,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1507,15 +1496,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_54_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_54_good.i
@@ -1507,7 +1507,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1516,7 +1515,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1534,7 +1532,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1570,14 +1567,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1633,15 +1622,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_61_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_61_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_61_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_61_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_63_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_63_bad.i
@@ -1355,7 +1355,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1364,7 +1363,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1382,7 +1380,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1418,14 +1415,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1481,15 +1470,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_63_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_63_good.i
@@ -1455,7 +1455,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1464,7 +1463,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1482,7 +1480,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1518,14 +1515,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1581,15 +1570,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_64_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_64_bad.i
@@ -1360,7 +1360,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1369,7 +1368,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1387,7 +1385,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1423,14 +1420,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1486,15 +1475,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_64_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_64_good.i
@@ -1465,7 +1465,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1474,7 +1473,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1492,7 +1490,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1528,14 +1525,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1591,15 +1580,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_65_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_65_bad.i
@@ -1353,7 +1353,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1362,7 +1361,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1380,7 +1378,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1416,14 +1413,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1479,15 +1468,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_65_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_65_good.i
@@ -1451,7 +1451,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1460,7 +1459,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1478,7 +1476,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1514,14 +1511,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1577,15 +1566,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_66_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_66_bad.i
@@ -1358,7 +1358,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1367,7 +1366,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1385,7 +1383,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1421,14 +1418,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1484,15 +1473,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_66_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_66_good.i
@@ -1461,7 +1461,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1470,7 +1469,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1488,7 +1486,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1524,14 +1521,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1587,15 +1576,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_67_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_67_bad.i
@@ -1364,7 +1364,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1373,7 +1372,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1391,7 +1389,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1427,14 +1424,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1490,15 +1479,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_67_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_67_good.i
@@ -1467,7 +1467,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1476,7 +1475,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1494,7 +1492,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1530,14 +1527,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1593,15 +1582,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_68_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_68_bad.i
@@ -1366,7 +1366,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1375,7 +1374,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1393,7 +1391,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1429,14 +1426,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1492,15 +1481,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_68_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_fscanf_68_good.i
@@ -1471,7 +1471,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1480,7 +1479,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1498,7 +1496,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1534,14 +1531,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1597,15 +1586,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_01_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_01_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_01_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_01_good.i
@@ -1501,7 +1501,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1510,7 +1509,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1528,7 +1526,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1564,14 +1561,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1627,15 +1616,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_02_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_02_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_02_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_02_good.i
@@ -1714,7 +1714,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1723,7 +1722,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1741,7 +1739,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1777,14 +1774,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1840,15 +1829,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_03_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_03_bad.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_03_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_03_good.i
@@ -1714,7 +1714,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1723,7 +1722,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1741,7 +1739,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1777,14 +1774,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1840,15 +1829,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_04_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_04_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_04_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_04_good.i
@@ -1735,7 +1735,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1744,7 +1743,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1762,7 +1760,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1798,14 +1795,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1861,15 +1850,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_05_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_05_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_05_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_05_good.i
@@ -1734,7 +1734,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1743,7 +1742,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1761,7 +1759,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1797,14 +1794,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1860,15 +1849,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_06_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_06_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_06_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_06_good.i
@@ -1733,7 +1733,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1742,7 +1741,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1760,7 +1758,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1796,14 +1793,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1859,15 +1848,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_07_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_07_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_07_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_07_good.i
@@ -1732,7 +1732,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1741,7 +1740,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1759,7 +1757,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1795,14 +1792,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1858,15 +1847,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_08_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_08_bad.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_08_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_08_good.i
@@ -1774,7 +1774,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1783,7 +1782,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1801,7 +1799,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1837,14 +1834,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1900,15 +1889,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_09_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_09_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_09_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_09_good.i
@@ -1731,7 +1731,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1740,7 +1739,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1758,7 +1756,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1794,14 +1791,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1857,15 +1846,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_10_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_10_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_10_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_10_good.i
@@ -1730,7 +1730,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1739,7 +1738,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1757,7 +1755,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1793,14 +1790,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1856,15 +1845,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_11_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_11_bad.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_11_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_11_good.i
@@ -1754,7 +1754,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1763,7 +1762,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1781,7 +1779,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1817,14 +1814,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1880,15 +1869,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_12_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_12_bad.i
@@ -1488,7 +1488,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1497,7 +1496,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1515,7 +1513,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1551,14 +1548,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1614,15 +1603,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_12_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_12_good.i
@@ -1705,7 +1705,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1714,7 +1713,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1732,7 +1730,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1768,14 +1765,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1831,15 +1820,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_13_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_13_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_13_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_13_good.i
@@ -1731,7 +1731,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1740,7 +1739,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1758,7 +1756,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1794,14 +1791,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1857,15 +1846,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_14_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_14_bad.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_14_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_14_good.i
@@ -1730,7 +1730,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1739,7 +1738,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1757,7 +1755,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1793,14 +1790,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1856,15 +1845,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_15_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_15_bad.i
@@ -1442,7 +1442,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1451,7 +1450,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1469,7 +1467,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1505,14 +1502,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1568,15 +1557,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_15_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_15_good.i
@@ -1834,7 +1834,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1843,7 +1842,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1861,7 +1859,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1897,14 +1894,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1960,15 +1949,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_16_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_16_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_16_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_16_good.i
@@ -1533,7 +1533,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1542,7 +1541,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1560,7 +1558,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1596,14 +1593,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1659,15 +1648,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_17_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_17_bad.i
@@ -1446,7 +1446,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1455,7 +1454,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1473,7 +1471,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1509,14 +1506,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1572,15 +1561,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_17_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_17_good.i
@@ -1569,7 +1569,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1578,7 +1577,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1596,7 +1594,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1632,14 +1629,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1695,15 +1684,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_18_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_18_bad.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_18_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_18_good.i
@@ -1517,7 +1517,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1526,7 +1525,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1544,7 +1542,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1580,14 +1577,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1643,15 +1632,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_21_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_21_bad.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_21_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_21_good.i
@@ -1684,7 +1684,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1693,7 +1692,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1711,7 +1709,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1747,14 +1744,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1810,15 +1799,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_22_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_22_bad.i
@@ -1430,7 +1430,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1439,7 +1438,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1457,7 +1455,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1493,14 +1490,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1556,15 +1545,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_22_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_22_good.i
@@ -1694,7 +1694,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1703,7 +1702,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1721,7 +1719,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1757,14 +1754,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1820,15 +1809,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_31_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_31_bad.i
@@ -1418,7 +1418,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1427,7 +1426,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1445,7 +1443,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1481,14 +1478,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1544,15 +1533,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_31_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_31_good.i
@@ -1513,7 +1513,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1522,7 +1521,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1540,7 +1538,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1576,14 +1573,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1639,15 +1628,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_32_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_32_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_32_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_32_good.i
@@ -1529,7 +1529,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1538,7 +1537,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1556,7 +1554,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1592,14 +1589,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1655,15 +1644,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_34_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_34_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_34_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_34_good.i
@@ -1522,7 +1522,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1531,7 +1530,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1549,7 +1547,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1585,14 +1582,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1648,15 +1637,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_41_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_41_bad.i
@@ -1419,7 +1419,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1428,7 +1427,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1446,7 +1444,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1482,14 +1479,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1545,15 +1534,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_41_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_41_good.i
@@ -1515,7 +1515,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1524,7 +1523,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1542,7 +1540,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1578,14 +1575,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1641,15 +1630,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_42_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_42_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_42_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_42_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_44_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_44_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_44_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_44_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_45_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_45_bad.i
@@ -1427,7 +1427,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1436,7 +1435,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1454,7 +1452,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1490,14 +1487,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1553,15 +1542,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_45_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_45_good.i
@@ -1531,7 +1531,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1540,7 +1539,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1558,7 +1556,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1594,14 +1591,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1657,15 +1646,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_51_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_51_bad.i
@@ -1422,7 +1422,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1431,7 +1430,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1449,7 +1447,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1485,14 +1482,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1548,15 +1537,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_51_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_51_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_52_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_52_bad.i
@@ -1428,7 +1428,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1437,7 +1436,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1455,7 +1453,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1491,14 +1488,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1554,15 +1543,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_52_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_52_good.i
@@ -1533,7 +1533,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1542,7 +1541,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1560,7 +1558,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1596,14 +1593,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1659,15 +1648,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_53_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_53_bad.i
@@ -1440,7 +1440,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1449,7 +1448,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1467,7 +1465,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1503,14 +1500,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1566,15 +1555,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_53_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_53_good.i
@@ -1557,7 +1557,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1566,7 +1565,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1584,7 +1582,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1620,14 +1617,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1683,15 +1672,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_54_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_54_bad.i
@@ -1449,7 +1449,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1458,7 +1457,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1476,7 +1474,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1512,14 +1509,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1575,15 +1564,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_54_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_54_good.i
@@ -1575,7 +1575,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1584,7 +1583,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1602,7 +1600,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1638,14 +1635,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1701,15 +1690,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_61_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_61_bad.i
@@ -1421,7 +1421,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1430,7 +1429,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1448,7 +1446,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1484,14 +1481,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1547,15 +1536,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_61_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_61_good.i
@@ -1519,7 +1519,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1528,7 +1527,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1546,7 +1544,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1582,14 +1579,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1645,15 +1634,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_63_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_63_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_63_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_63_good.i
@@ -1529,7 +1529,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1538,7 +1537,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1556,7 +1554,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1592,14 +1589,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1655,15 +1644,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_64_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_64_bad.i
@@ -1425,7 +1425,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1434,7 +1433,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1452,7 +1450,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1488,14 +1485,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1551,15 +1540,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_64_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_64_good.i
@@ -1527,7 +1527,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1536,7 +1535,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1554,7 +1552,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1590,14 +1587,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1653,15 +1642,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_65_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_65_bad.i
@@ -1424,7 +1424,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1433,7 +1432,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1451,7 +1449,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1487,14 +1484,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1550,15 +1539,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_65_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_65_good.i
@@ -1525,7 +1525,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1534,7 +1533,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1552,7 +1550,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1588,14 +1585,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1651,15 +1640,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_66_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_66_bad.i
@@ -1426,7 +1426,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1435,7 +1434,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1453,7 +1451,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1489,14 +1486,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1552,15 +1541,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_66_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_66_good.i
@@ -1529,7 +1529,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1538,7 +1537,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1556,7 +1554,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1592,14 +1589,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1655,15 +1644,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_67_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_67_bad.i
@@ -1435,7 +1435,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1444,7 +1443,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1462,7 +1460,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1498,14 +1495,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1561,15 +1550,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_67_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_67_good.i
@@ -1541,7 +1541,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1550,7 +1549,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1568,7 +1566,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1604,14 +1601,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1667,15 +1656,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_68_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_68_bad.i
@@ -1434,7 +1434,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1443,7 +1442,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1461,7 +1459,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1497,14 +1494,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1560,15 +1549,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_68_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_listen_socket_68_good.i
@@ -1539,7 +1539,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1548,7 +1547,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1566,7 +1564,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1602,14 +1599,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1665,15 +1654,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_01_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_01_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_01_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_01_good.i
@@ -1382,7 +1382,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1391,7 +1390,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1409,7 +1407,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1445,14 +1442,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1508,15 +1497,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_02_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_02_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_02_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_02_good.i
@@ -1541,7 +1541,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1550,7 +1549,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1568,7 +1566,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1604,14 +1601,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1667,15 +1656,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_03_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_03_bad.i
@@ -1293,7 +1293,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1302,7 +1301,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1320,7 +1318,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1356,14 +1353,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1419,15 +1408,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_03_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_03_good.i
@@ -1541,7 +1541,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1550,7 +1549,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1568,7 +1566,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1604,14 +1601,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1667,15 +1656,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_04_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_04_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_04_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_04_good.i
@@ -1566,7 +1566,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1575,7 +1574,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1593,7 +1591,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1629,14 +1626,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1692,15 +1681,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_05_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_05_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_05_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_05_good.i
@@ -1565,7 +1565,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1574,7 +1573,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1592,7 +1590,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1628,14 +1625,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1691,15 +1680,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_06_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_06_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_06_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_06_good.i
@@ -1564,7 +1564,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1573,7 +1572,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1591,7 +1589,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1627,14 +1624,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1690,15 +1679,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_07_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_07_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_07_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_07_good.i
@@ -1563,7 +1563,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1572,7 +1571,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1590,7 +1588,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1626,14 +1623,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1689,15 +1678,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_08_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_08_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_08_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_08_good.i
@@ -1605,7 +1605,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1614,7 +1613,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1632,7 +1630,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1668,14 +1665,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1731,15 +1720,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_09_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_09_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_09_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_09_good.i
@@ -1562,7 +1562,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1571,7 +1570,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1589,7 +1587,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1625,14 +1622,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1688,15 +1677,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_10_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_10_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_10_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_10_good.i
@@ -1561,7 +1561,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1570,7 +1569,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1588,7 +1586,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1624,14 +1621,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1687,15 +1676,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_11_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_11_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_11_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_11_good.i
@@ -1585,7 +1585,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1594,7 +1593,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1612,7 +1610,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1648,14 +1645,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1711,15 +1700,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_12_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_12_bad.i
@@ -1371,7 +1371,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1380,7 +1379,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1398,7 +1396,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1434,14 +1431,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1497,15 +1486,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_12_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_12_good.i
@@ -1536,7 +1536,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1545,7 +1544,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1563,7 +1561,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1599,14 +1596,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1662,15 +1651,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_13_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_13_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_13_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_13_good.i
@@ -1562,7 +1562,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1571,7 +1570,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1589,7 +1587,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1625,14 +1622,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1688,15 +1677,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_14_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_14_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_14_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_14_good.i
@@ -1561,7 +1561,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1570,7 +1569,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1588,7 +1586,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1624,14 +1621,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1687,15 +1676,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_15_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_15_bad.i
@@ -1323,7 +1323,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1332,7 +1331,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1350,7 +1348,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1386,14 +1383,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1449,15 +1438,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_15_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_15_good.i
@@ -1661,7 +1661,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1670,7 +1669,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1688,7 +1686,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1724,14 +1721,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1787,15 +1776,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_16_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_16_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_16_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_16_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_17_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_17_bad.i
@@ -1327,7 +1327,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1336,7 +1335,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1354,7 +1352,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1390,14 +1387,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1453,15 +1442,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_17_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_17_good.i
@@ -1450,7 +1450,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1459,7 +1458,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1477,7 +1475,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1513,14 +1510,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1576,15 +1565,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_18_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_18_bad.i
@@ -1301,7 +1301,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1310,7 +1309,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1328,7 +1326,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1364,14 +1361,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1427,15 +1416,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_18_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_18_good.i
@@ -1398,7 +1398,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1407,7 +1406,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1425,7 +1423,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1461,14 +1458,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1524,15 +1513,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_21_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_21_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_21_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_21_good.i
@@ -1511,7 +1511,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1520,7 +1519,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1538,7 +1536,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1574,14 +1571,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1637,15 +1626,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_22_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_22_bad.i
@@ -1311,7 +1311,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1320,7 +1319,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1338,7 +1336,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1374,14 +1371,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1437,15 +1426,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_22_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_22_good.i
@@ -1521,7 +1521,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1530,7 +1529,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1548,7 +1546,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1584,14 +1581,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1647,15 +1636,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_31_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_31_bad.i
@@ -1299,7 +1299,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1308,7 +1307,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1326,7 +1324,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1362,14 +1359,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1425,15 +1414,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_31_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_31_good.i
@@ -1394,7 +1394,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1403,7 +1402,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1421,7 +1419,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1457,14 +1454,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1520,15 +1509,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_32_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_32_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_32_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_32_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_34_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_34_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_34_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_34_good.i
@@ -1403,7 +1403,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1412,7 +1411,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1430,7 +1428,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1466,14 +1463,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1529,15 +1518,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_41_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_41_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_41_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_41_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_42_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_42_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_42_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_42_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_44_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_44_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_44_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_44_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_45_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_45_bad.i
@@ -1308,7 +1308,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1317,7 +1316,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1335,7 +1333,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1371,14 +1368,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1434,15 +1423,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_45_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_45_good.i
@@ -1412,7 +1412,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1421,7 +1420,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1439,7 +1437,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1475,14 +1472,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1538,15 +1527,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_51_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_51_bad.i
@@ -1300,7 +1300,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1309,7 +1308,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1327,7 +1325,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1363,14 +1360,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1426,15 +1415,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_51_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_51_good.i
@@ -1396,7 +1396,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1405,7 +1404,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1423,7 +1421,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1459,14 +1456,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1522,15 +1511,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_52_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_52_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_52_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_52_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_53_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_53_bad.i
@@ -1318,7 +1318,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1327,7 +1326,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1345,7 +1343,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1381,14 +1378,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1444,15 +1433,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_53_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_53_good.i
@@ -1432,7 +1432,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1441,7 +1440,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1459,7 +1457,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1495,14 +1492,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1558,15 +1547,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_54_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_54_bad.i
@@ -1333,7 +1333,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1342,7 +1341,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1360,7 +1358,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1396,14 +1393,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1459,15 +1448,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_54_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_54_good.i
@@ -1462,7 +1462,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1471,7 +1470,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1489,7 +1487,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1525,14 +1522,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1588,15 +1577,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_61_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_61_bad.i
@@ -1305,7 +1305,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1314,7 +1313,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1332,7 +1330,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1368,14 +1365,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1431,15 +1420,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_61_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_61_good.i
@@ -1406,7 +1406,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1415,7 +1414,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1433,7 +1431,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1469,14 +1466,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1532,15 +1521,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_63_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_63_bad.i
@@ -1304,7 +1304,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1313,7 +1312,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1331,7 +1329,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1367,14 +1364,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1430,15 +1419,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_63_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_63_good.i
@@ -1404,7 +1404,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1413,7 +1412,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1431,7 +1429,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1467,14 +1464,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1530,15 +1519,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_64_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_64_bad.i
@@ -1309,7 +1309,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1318,7 +1317,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1336,7 +1334,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1372,14 +1369,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1435,15 +1424,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_64_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_64_good.i
@@ -1414,7 +1414,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1423,7 +1422,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1441,7 +1439,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1477,14 +1474,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1540,15 +1529,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_65_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_65_bad.i
@@ -1302,7 +1302,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1311,7 +1310,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1329,7 +1327,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1365,14 +1362,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1428,15 +1417,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_65_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_65_good.i
@@ -1400,7 +1400,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1409,7 +1408,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1427,7 +1425,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1463,14 +1460,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1526,15 +1515,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_66_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_66_bad.i
@@ -1307,7 +1307,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1316,7 +1315,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1334,7 +1332,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1370,14 +1367,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1433,15 +1422,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_66_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_66_good.i
@@ -1410,7 +1410,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1419,7 +1418,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1437,7 +1435,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1473,14 +1470,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1536,15 +1525,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_67_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_67_bad.i
@@ -1313,7 +1313,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1322,7 +1321,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1340,7 +1338,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1376,14 +1373,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1439,15 +1428,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_67_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_67_good.i
@@ -1416,7 +1416,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1425,7 +1424,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1443,7 +1441,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1479,14 +1476,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1542,15 +1531,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_68_bad.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_68_bad.i
@@ -1315,7 +1315,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1324,7 +1323,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1342,7 +1340,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1378,14 +1375,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1441,15 +1430,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 

--- a/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_68_good.i
+++ b/c/Juliet_Test/CWE789_Uncontrolled_Mem_Alloc---s01---CWE789_Uncontrolled_Mem_Alloc__malloc_char_rand_68_good.i
@@ -1420,7 +1420,6 @@ unsigned long ldv_undef_ulong(void);
 unsigned long long ldv_undef_ulonglong(void);
 
 
-void *ldv_undef_ptr(void);
 
 
 int ldv_undef_int_negative(void);
@@ -1429,7 +1428,6 @@ int ldv_undef_int_negative(void);
 int ldv_undef_int_nonpositive(void);
 
 
-void *ldv_undef_ptr_non_null(void);
 
 
 int __VERIFIER_nondet_int(void);
@@ -1447,7 +1445,6 @@ unsigned long __VERIFIER_nondet_ulong(void);
 unsigned long long __VERIFIER_nondet_ulonglong(void);
 
 
-void *__VERIFIER_nondet_pointer(void);
 
 
 int ldv_undef_int(void)
@@ -1483,14 +1480,6 @@ unsigned int ldv_undef_uint(void)
 }
 
 
-void *ldv_undef_ptr(void)
-{
-  void *tmp;
-  
-  tmp = __VERIFIER_nondet_pointer();
-  
-  return tmp;
-}
 
 
 unsigned long ldv_undef_ulong(void)
@@ -1546,15 +1535,6 @@ int ldv_undef_int_nonpositive(void)
 }
 
 
-void *ldv_undef_ptr_non_null(void)
-{
-  
-  void *ret = ldv_undef_ptr();
-  
-  __VERIFIER_assume(ret != (void *)0);
-  
-  return ret;
-}
 
 
 


### PR DESCRIPTION
This removes a set of calls to __VERIFIER_nondet_pointer (though none of
those were ever made, it's just a cleanup of the code).

The changes were done using the following command:
```
for f in c/Juliet_Test/*.[ci]
do
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^void \*ldv_undef_ptr_non_null\(void\)/) {
       if(/;$/) { $p = 1; } else { $p = 2; }
     }
     elsif($p == 2) { if(/^\}$/) { $p++; } }
     else { print; }
   }' \
  $f
done
for f in c/Juliet_Test/*.[ci]
do
perl -i -e \
  '$p = 1;
   while(<>) {
     if(/^void \*ldv_undef_ptr\(void\)/) {
       if(/;$/) { $p = 1; } else { $p = 2; }
     }
     elsif($p == 2) { if(/^\}$/) { $p++; } }
     else { print; }
   }' \
  $f
sed -i '/^void \*__VERIFIER_nondet_pointer(void);$/d' $f
done
```
